### PR TITLE
Unrefined new version for further development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ else
 SHELL := /bin/bash
 endif
 
-SCHEMA_VERSION := 1.0
+SCHEMA_VERSION := 2.0
 CURR_SCHEMA := unitsml-v${SCHEMA_VERSION}
 
 UNITSMLSRC := $(wildcard unitsml/*.xsd) unitsml/$(CURR_SCHEMA).xsd

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -59,6 +59,120 @@ PURPOSE.
 		<xsd:annotation>
 			<xsd:documentation>Container for UnitsML units, quantities, and prefixes.</xsd:documentation>
 		</xsd:annotation>
+	    <xsd:unique name="UniqueUnitSet">
+	        <xsd:annotation>
+	            <xsd:documentation>The uniqueness constraint allows to aggregate multiple objects from different authorities within a single UnitsML element.</xsd:documentation>
+	        </xsd:annotation>
+	        <xsd:selector xpath="unitsml:UnitSet/unitsml:Unit"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:unique>
+	    <xsd:unique name="UniqueCountedItemSet">
+	        <xsd:annotation>
+	            <xsd:documentation>The uniqueness constraint allows to aggregate multiple objects from different authorities within a single UnitsML element.</xsd:documentation>
+	        </xsd:annotation>
+	        <xsd:selector xpath="unitsml:CountedItemSet/unitsml:CountedItem"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:unique>
+	    <xsd:unique name="UniqueQuantitySet">
+	        <xsd:annotation>
+	            <xsd:documentation>The uniqueness constraint allows to aggregate multiple objects from different authorities within a single UnitsML element.</xsd:documentation>
+	        </xsd:annotation>
+	        <xsd:selector xpath="unitsml:QuantitySet/unitsml:Quantity"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:unique>
+	    <xsd:unique name="UniqueDimensionSet">
+	        <xsd:annotation>
+	            <xsd:documentation>The uniqueness constraint allows to aggregate multiple objects from different authorities within a single UnitsML element.</xsd:documentation>
+	        </xsd:annotation>
+	        <xsd:selector xpath="unitsml:DimensionSet/unitsml:Dimension"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:unique>
+	    <xsd:unique name="UniquePrefixSet">
+	        <xsd:annotation>
+	            <xsd:documentation>The uniqueness constraint allows to aggregate multiple objects from different authorities within a single UnitsML element.</xsd:documentation>
+	        </xsd:annotation>
+	        <xsd:selector xpath="unitsml:PrefixSet/unitsml:Prefix"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	    </xsd:unique>
+	    <xsd:unique name="UniqueConstantSet">
+	        <xsd:annotation>
+	            <xsd:documentation>The uniqueness constraint allows to aggregate multiple objects from different authorities within a single UnitsML element.</xsd:documentation>
+	        </xsd:annotation>
+	        <xsd:selector xpath="unitsml:ConstantSet/unitsml:Constant"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:unique>
+	    <xsd:unique name="UniqueRegulatoryBodies">
+	        <xsd:selector xpath="unitsml:RegulatoryBody"/>
+	        <xsd:field xpath="@domainKey"/>
+	    </xsd:unique>
+	    <xsd:keyref name="UniqueUnitSetRef" refer="unitsml:UniqueUnitSet">
+	        <xsd:selector xpath=".//unitsml:UnitReference"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="UnitUniqueUnitSetRef" refer="unitsml:UniqueUnitSet">
+	        <xsd:selector xpath="unitsml:UnitSet/unitsml:Unit/unitsml:PreviousVersion"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="UniqueCountedItemSetRef" refer="unitsml:UniqueCountedItemSet">
+	        <xsd:selector xpath=".//unitsml:CountableItemReference"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="CountedItemUniqueCountedItemSetRef" refer="unitsml:UniqueCountedItemSet">
+	        <xsd:selector xpath="unitsml:CountedItemSet/unitsml:CountedItem/unitsml:PreviousVersion"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="UniqueQuantitySetRef" refer="unitsml:UniqueQuantitySet">
+	        <xsd:selector xpath=".//unitsml:QuantityReference"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="QuantityUniqueQuantitySetRef" refer="unitsml:UniqueQuantitySet">
+	        <xsd:selector xpath="unitsml:QuantitySet/unitsml:Quantity/unitsml:PreviousVersion"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="UniqueDimensionSetRef" refer="unitsml:UniqueDimensionSet">
+	        <xsd:selector xpath=".//unitsml:DimensionReference"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="UniquePrefixSetRef" refer="unitsml:UniquePrefixSet">
+	        <xsd:selector xpath=".//unitsml:PrefixReference"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="ConstantUniqueConstantSetRef" refer="unitsml:UniqueConstantSet">
+	        <xsd:selector xpath="unitsml:ConstantSet/unitsml:Constant/unitsml:PreviousVersion"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:keyref>
+	    <xsd:keyref name="UniqueRegulatoryBodiesRef" refer="unitsml:UniqueRegulatoryBodies">
+	        <xsd:selector xpath="./unitsml:UnitSet | ./unitsml:CountedItemSet | ./unitsml:QuantitySet | ./unitsml:DimensionSet | ./unitsml:PrefixSet | ./unitsml:ConstantSet | ./unitsml:UnitSet/unitsml:Unit | ./unitsml:CountedItemSet/unitsml:CountedItem | ./unitsml:QuantitySet/unitsml:Quantity | ./unitsml:DimensionSet/unitsml:Dimension | ./unitsml:PrefixSet/unitsml:Prefix | ./unitsml:ConstantSet/unitsml:Constant"/>
+	        <xsd:field xpath="@domain"/>
+	    </xsd:keyref>
 	</xsd:element>
 	<xsd:complexType name="UnitsMLType">
 		<xsd:annotation>
@@ -72,8 +186,145 @@ PURPOSE.
 		    <xsd:element ref="unitsml:DimensionSet" minOccurs="0" maxOccurs="unbounded"/>
 		    <xsd:element ref="unitsml:PrefixSet" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
+	    <xsd:assert test="
+	        every $var in unitsml:UnitSet/unitsml:Unit[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (
+	           if (exists(unitsml:UnitSet/unitsml:Unit[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               if (exists(unitsml:UnitSet/unitsml:Unit[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp)) then
+	                   unitsml:UnitSet/unitsml:Unit[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp lt $var/@timeStamp
+	               else
+            	        true()
+                else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>If a PreviousVersion element is used to reference a parent, check that the descendent does not predate the parent.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:CountedItemSet/unitsml:CountedItem[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (
+	           if (exists(unitsml:CountedItemSet/unitsml:CountedItem[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               if (exists(unitsml:CountedItemSet/unitsml:CountedItem[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp)) then
+	                   unitsml:CountedItemSet/unitsml:CountedItem[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp lt $var/@timeStamp
+	               else
+	                   true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>If a PreviousVersion element is used to reference a parent, check that the descendent does not predate the parent.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:QuantitySet/unitsml:Quantity[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (
+	           if (exists(unitsml:QuantitySet/unitsml:Quantity[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               if (exists(unitsml:QuantitySet/unitsml:Quantity[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp)) then
+	                   unitsml:QuantitySet/unitsml:Quantity[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp lt $var/@timeStamp
+	               else
+	                   true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>If a PreviousVersion element is used to reference a parent, check that the descendent does not predate the parent.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:DimensionSet/unitsml:Dimension[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (
+	           if (exists(unitsml:DimensionSet/unitsml:Dimension[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               if (exists(unitsml:DimensionSet/unitsml:Dimension[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp)) then
+	                   unitsml:DimensionSet/unitsml:Dimension[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp lt $var/@timeStamp
+	               else
+	                   true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>If a PreviousVersion element is used to reference a parent, check that the descendent does not predate the parent.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:ConstantSet/unitsml:Constant[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (
+	           if (exists(unitsml:ConstantSet/unitsml:Constant[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               if (exists(unitsml:ConstantSet/unitsml:Constant[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp)) then
+	                   unitsml:ConstantSet/unitsml:Constant[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)]/@timeStamp lt $var/@timeStamp
+	               else
+	                   true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>If a PreviousVersion element is used to reference a parent, check that the descendent does not predate the parent.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <!-- Global assert for previous version references allows for cross set history references(if one would like to separate versions into sets) -->
+	    <xsd:assert test="
+	        every $var in unitsml:UnitSet/unitsml:Unit[exists(unitsml:PreviousVersion) and exists(@version)] satisfies (
+	           if (exists(unitsml:UnitSet/unitsml:Unit[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>Require that a linear version history is maintained. This does not allow branching.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:CountedItemSet/unitsml:CountedItem[exists(unitsml:PreviousVersion) and exists(@version)] satisfies (
+	           if (exists(unitsml:CountedItemSet/unitsml:CountedItem[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>Require that a linear version history is maintained. This does not allow branching.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:QuantitySet/unitsml:Quantity[exists(unitsml:PreviousVersion) and exists(@version)] satisfies (
+	           if (exists(unitsml:QuantitySet/unitsml:Quantity[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               true()
+               else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>Require that a linear version history is maintained. This does not allow branching.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:DimensionSet/unitsml:Dimension[exists(unitsml:PreviousVersion) and exists(@version)] satisfies (
+	           if (exists(unitsml:DimensionSet/unitsml:Dimension[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>Require that a linear version history is maintained. This does not allow branching.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
+	    <xsd:assert test="
+	        every $var in unitsml:ConstantSet/unitsml:Constant[exists(unitsml:PreviousVersion) and exists(@version)] satisfies (
+	           if (exists(unitsml:ConstantSet/unitsml:Constant[(@domain eq $var/unitsml:PreviousVersion/@domain) and (@key eq $var/unitsml:PreviousVersion/@key) and (@version eq $var/unitsml:PreviousVersion/@version)])) then
+	               true()
+	           else
+	               false())">
+	        <xsd:annotation>
+	            <xsd:documentation>Require that a linear version history is maintained. This does not allow branching.</xsd:documentation>
+	        </xsd:annotation>
+	    </xsd:assert>
 	</xsd:complexType>
 	<!--=== Global document elements ===-->
+    <xsd:element name="DimensionReference" type="unitsml:KeyedReferenceType">
+        <xsd:annotation>
+            <xsd:documentation>Element referencing a Dimension entity.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:element name="UnitReference">
+        <xsd:annotation>
+            <xsd:documentation>Element for referencing a unit of measure from within the Quantity element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:alternative test="@url" type="unitsml:ReferenceType"/>
+        <xsd:alternative test="@domain" type="unitsml:KeyedReferenceType"/>
+        <xsd:alternative type="unitsml:ReferenceType"/>
+    </xsd:element>
+    <xsd:element name="CountableItemReference">
+        <xsd:annotation>
+            <xsd:documentation>Element for referencing a countable item from.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:alternative test="@url" type="unitsml:ReferenceType"/>
+        <xsd:alternative test="@domain" type="unitsml:KeyedReferenceType"/>
+        <xsd:alternative type="unitsml:ReferenceType"/>
+    </xsd:element>
     <!--     === Regulatory body elements ===-->
     <xsd:element name="RegulatoryBody" type="unitsml:RegulatoryBodyType">
         <xsd:annotation>
@@ -95,6 +346,12 @@ PURPOSE.
 		<xsd:annotation>
 			<xsd:documentation>Element for describing units. Use in containers UnitSet or directly incorporate into a host schema.</xsd:documentation>
 		</xsd:annotation>
+	    <xsd:unique name="UniqueQuantityReferenceInUnit">
+	        <xsd:selector xpath="unitsml:QuantityReference"/>
+	        <xsd:field xpath="@domain"/>
+	        <xsd:field xpath="@key"/>
+	        <xsd:field xpath="@version"/>
+	    </xsd:unique>
 	</xsd:element>
 	<xsd:element name="UnitSystem" type="unitsml:SystemType">
 		<xsd:annotation>
@@ -171,11 +428,14 @@ PURPOSE.
 			<xsd:documentation>Element for a description of the SpecialConversionFrom.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityReference" type="unitsml:ReferenceType">
-		<xsd:annotation>
-			<xsd:documentation>Element for all quantities that can be expressed using this unit.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
+    <xsd:element name="QuantityReference">
+        <xsd:annotation>
+            <xsd:documentation>Element for all quantities that can be expressed using this unit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:alternative test="@url" type="unitsml:ReferenceType"/>
+        <xsd:alternative test="@domain" type="unitsml:KeyedReferenceType"/>
+        <xsd:alternative type="unitsml:ReferenceType"/>
+    </xsd:element>
 	<xsd:element name="UnitDefinition" type="unitsml:DefinitionType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the definition of the unit.</xsd:documentation>
@@ -242,6 +502,12 @@ PURPOSE.
 		<xsd:annotation>
 			<xsd:documentation>Element for describing quantities and referencing corresponding units. Use in container or directly incorporate into a host schema.</xsd:documentation>
 		</xsd:annotation>
+		<xsd:unique name="UniqueUnitReferenceInQuantity">
+			<xsd:selector xpath="unitsml:UnitReference"/>
+			<xsd:field xpath="@domain"/>
+			<xsd:field xpath="@unitKey"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
 	</xsd:element>
 	<xsd:element name="QuantityName" type="unitsml:NameType">
 		<xsd:annotation>
@@ -251,11 +517,6 @@ PURPOSE.
 	<xsd:element name="QuantitySymbol" type="unitsml:SymbolType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:element name="UnitReference" type="unitsml:ReferenceType">
-		<xsd:annotation>
-			<xsd:documentation>Element for referencing a unit of measure from within the Quantity element.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="QuantityVersionHistory" type="unitsml:NoteType">
@@ -356,6 +617,53 @@ PURPOSE.
 		</xsd:annotation>
 	</xsd:element>
 	<!--=== Attribute groups (global) ===-->
+    <xsd:attributeGroup name="timestamp">
+        <xsd:attribute name="timeStamp" type="xsd:dateTime">
+            <xsd:annotation>
+                <xsd:documentation>Used to indicate the timepoint from which onward this element may be referenced.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:attributeGroup>
+    <xsd:attributeGroup name="keyedReferenceAttributeGroup">
+        <xsd:annotation>
+            <xsd:documentation>Attributes required for all reference elements.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="domain" type="xsd:token" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Domain of the referenced object.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="key" type="xsd:token" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Key of the referenced object.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="version" type="xsd:positiveInteger" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Version of the referenced object.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:attributeGroup>
+    <xsd:attributeGroup name="optionalKeyedReferenceAttributeGroup">
+        <xsd:annotation>
+            <xsd:documentation>Attributes required for all reference elements.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="domain" type="xsd:token" use="optional">
+            <xsd:annotation>
+                <xsd:documentation>Domain of the referenced object.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="key" type="xsd:token" use="optional">
+            <xsd:annotation>
+                <xsd:documentation>Key of the referenced object.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="version" type="xsd:positiveInteger" use="optional">
+            <xsd:annotation>
+                <xsd:documentation>Version of the referenced object.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:attributeGroup>
 	<xsd:attributeGroup name="initialUnit">
 		<xsd:annotation>
 			<xsd:documentation>URI indicating the unitID of the starting unit for the conversion. For units which are defined in the same document, the URI should consist of a pound sign (#) followed by the ID value.</xsd:documentation>
@@ -451,12 +759,28 @@ PURPOSE.
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
+		<xsd:attribute name="domain" type="xsd:token" use="optional" inheritable="true">
+			<xsd:annotation>
+				<xsd:documentation>Sets the restricted domain for the entire
+					set.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:assert test="
+			if (exists(@domain)) then
+			empty(./unitsml:Unit[@domain ne ../@domain])
+			else
+			true()">
+			<xsd:annotation>
+				<xsd:documentation>If a domain is given for a set, every member of the set must belong to the same domain.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<xsd:complexType name="UnitType">
 		<xsd:annotation>
 			<xsd:documentation>Type for the unit.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<xsd:element ref="unitsml:DimensionReference" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:UnitSystem" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Container for describing the system(s) of units.</xsd:documentation>
@@ -477,21 +801,49 @@ PURPOSE.
 					<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:UnitDefinition" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:UnitHistory" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:UnitRemark" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
-		<xsd:attribute ref="xml:id" use="required"/>
-		<xsd:attribute name="timeStamp" type="xsd:dateTime">
-			<xsd:annotation>
-				<xsd:documentation>Used to indicate the version of the unit output from the Units Database. Changes in the time-stamp are made if a substantive change has been made to the unit, such as a change in the unit definition or changes in conversion factors.</xsd:documentation>
-			</xsd:annotation>
-		</xsd:attribute>
+		<xsd:attribute ref="xml:id" use="optional"/>
+		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
+		<xsd:attributeGroup ref="unitsml:timestamp"/>
 		<xsd:attributeGroup ref="unitsml:dimensionURL">
 			<xsd:annotation>
 				<xsd:documentation>Reference to a representation of the unit or quantity in terms of the 7 SI base dimensions.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attributeGroup>
+		<xsd:assert test="(@xml:id or (@domain and @key and @version))">
+			<xsd:annotation>
+				<xsd:documentation>Require at least one identification type via xml:id or domain,
+					key, version triplet or both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(not(@domain) and not(@key) and not(@version)) or (@domain and @key and @version)">
+			<xsd:annotation>
+				<xsd:documentation>Do not allow a partial reference</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert test="
+			if (@version and (@version > 1)) then
+				(exists(./unitsml:PreviousVersion) and (./unitsml:PreviousVersion/@version eq @version - 1) and (@key eq ./unitsml:PreviousVersion/@key) and (@domain eq ./unitsml:PreviousVersion/@domain))
+			else
+				not(exists(./unitsml:PreviousVersion))">
+			<xsd:annotation>
+				<xsd:documentation>If a version is specified then this constraint ensures a linear
+					version history of the unit. Does not allow for a PreviousVersion element when
+					version &lt; 2.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(@dimensionURL and not(exists(./unitsml:DimensionReference))) or (not(@dimensionURL) and exists(./unitsml:DimensionReference)) or (not(@dimensionURL) and not(exists(./unitsml:DimensionReference)))">
+			<xsd:annotation>
+				<xsd:documentation>Allow a reference to a Dimension via the dimensionURL or a
+					DimensionReference element but not both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<xsd:complexType name="CodeListValueType">
 		<xsd:annotation>
@@ -517,6 +869,7 @@ PURPOSE.
 				<xsd:documentation>Suggested retrieval location for this version of the code list.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<!-- TODO: could possibly be a vcard -->
 		<xsd:attribute name="organizationName" type="xsd:normalizedString">
 			<xsd:annotation>
 				<xsd:documentation>Organization responsible for publication and/or maintenance of the code list.</xsd:documentation>
@@ -537,18 +890,55 @@ PURPOSE.
 		<xsd:annotation>
 			<xsd:documentation>Type for the container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered base units.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element ref="unitsml:EnumeratedRootUnit" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Element for a root unit (from an extensive enumerated list) allowing an optional prefix and power. E.g., mm^2</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element ref="unitsml:ExternalRootUnit" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Element for those special cases where the root unit needed is not included in the enumerated list in the above element.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
+		<xsd:choice>
+			<xsd:sequence>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="unitsml:EnumeratedRootUnit">
+						<xsd:annotation>
+							<xsd:documentation>Element for a root unit (from an extensive enumerated
+								list) allowing an optional prefix and power. E.g.,
+								mm^2</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element ref="unitsml:ExternalRootUnit">
+						<xsd:annotation>
+							<xsd:documentation>Element for those special cases where the root unit
+								needed is not included in the enumerated list in the above
+								element.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:sequence>
+			<xsd:sequence>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="UnitReference"
+						type="unitsml:KeyedReferenceUnitWithPowerRationalType">
+						<xsd:annotation>
+							<xsd:documentation>Element for specifying particular units associated
+								with the quantity.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="PrefixReference">
+						<xsd:complexType>
+							<xsd:complexContent>
+								<xsd:extension base="unitsml:KeyedReferencePrefixType">
+									<xsd:sequence>
+										<xsd:element name="UnitReference"
+											type="unitsml:KeyedReferenceUnitWithPowerRationalType">
+											<xsd:annotation>
+												<xsd:documentation>Element for specifying particular
+													units associated with the
+													quantity.</xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+									</xsd:sequence>
+								</xsd:extension>
+							</xsd:complexContent>
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:choice>
 	</xsd:complexType>
 	<xsd:complexType name="EnumeratedRootUnitType">
 		<xsd:annotation>
@@ -726,6 +1116,21 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:sequence>
 			<xsd:element ref="unitsml:CountedItem" maxOccurs="unbounded"/>
 		</xsd:sequence>
+	<xsd:attribute name="domain" type="xsd:token" use="optional" inheritable="true">
+			<xsd:annotation>
+				<xsd:documentation>Sets the restricted domain for the entire
+					set.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:assert test="
+				if (exists(@domain)) then
+					empty(./unitsml:CountedItem[@domain ne ../@domain])
+				else
+					true()">
+			<xsd:annotation>
+				<xsd:documentation>If a domain is given for a set, every member of the set must belong to the same domain.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<xsd:complexType name="CountedItemType">
 		<xsd:annotation>
@@ -735,11 +1140,34 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:element ref="unitsml:ItemName" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ItemSymbol" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ItemVersionHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:ItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ItemHistory" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ItemRemark" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
-		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute ref="xml:id" use="optional"/>
+		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
+		<xsd:attributeGroup ref="unitsml:timestamp"/>
+		<xsd:assert test="(@xml:id or (@domain and @key and @version))">
+			<xsd:annotation>
+				<xsd:documentation>Require at least one identification type via xml:id or domain, key, version triplet or both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(not(@domain) and not(@key) and not(@version)) or (@domain and @key and @version)">
+			<xsd:annotation>
+				<xsd:documentation>Do not allow a partial reference</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert test="
+			if (@version and (@version > 1)) then
+				(exists(./unitsml:PreviousVersion) and (./unitsml:PreviousVersion/@version eq @version - 1) and (@key eq ./unitsml:PreviousVersion/@key) and (@domain eq ./unitsml:PreviousVersion/@domain))
+			else
+				not(exists(./unitsml:PreviousVersion))">
+			<xsd:annotation>
+				<xsd:documentation>If a version is specified then this constraint ensures a linear version history of the unit. Does not allow for a PreviousVersion element when version &lt; 2.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<!--     === Quantity specific Types ===-->
 	<xsd:complexType name="QuantitySetType">
@@ -749,33 +1177,65 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:sequence>
 			<xsd:element ref="unitsml:Quantity" maxOccurs="unbounded"/>
 		</xsd:sequence>
+	<xsd:attribute name="domain" type="xsd:token" use="optional" inheritable="true">
+			<xsd:annotation>
+				<xsd:documentation>Sets the restricted domain for the entire
+					set.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:assert test="
+				if (exists(@domain)) then
+					empty(./unitsml:Quantity[@domain ne ../@domain])
+				else
+					true()">
+			<xsd:annotation>
+				<xsd:documentation>If a domain is given for a set, every member of the set must belong to the same domain.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<xsd:complexType name="QuantityType">
 		<xsd:annotation>
 			<xsd:documentation>Type for the quantity.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<xsd:element ref="unitsml:DimensionReference" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:QuantityName" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:QuantitySymbol" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="unitsml:UnitReference" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Element for specifying particular units associated with the quantity.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element ref="unitsml:UnitReference" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Element for specifying particular units associated with the
+								quantity.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>					
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element ref="unitsml:CountableItemReference" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Element for specifying particular countable items associated with the
+								quantity.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:choice>
 			<xsd:element ref="unitsml:QuantityVersionHistory" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for descriptive information, including version changes to the quantity.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:QuantityDefinition" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:QuantityHistory" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:QuantityRemark" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
-		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute ref="xml:id" use="optional"/>
+		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
+		<xsd:attributeGroup ref="unitsml:timestamp"/>
 		<xsd:attribute name="quantityType" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>Type of the quantity.  For example base or derived.</xsd:documentation>
@@ -789,6 +1249,36 @@ additive inverse of this number.</xsd:documentation>
 			<!-- REVISE -->
 		</xsd:attribute>
 		<xsd:attributeGroup ref="unitsml:dimensionURL"/>
+		<xsd:assert test="(@xml:id or (@domain and @key and @version))">
+			<xsd:annotation>
+				<xsd:documentation>Require at least one identification type via xml:id or domain,
+					key, version triplet or both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(not(@domain) and not(@key) and not(@version)) or (@domain and @key and @version)">
+			<xsd:annotation>
+				<xsd:documentation>Do not allow a partial reference.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert test="
+			if (@version and (@version > 1)) then
+				(exists(./unitsml:PreviousVersion) and (./unitsml:PreviousVersion/@version eq @version - 1) and (@key eq ./unitsml:PreviousVersion/@key) and (@domain eq ./unitsml:PreviousVersion/@domain))
+			else
+				not(exists(./unitsml:PreviousVersion))">
+			<xsd:annotation>
+				<xsd:documentation>If a version is specified then this constraint ensures a linear
+					version history of the unit. Does not allow for a PreviousVersion element when
+					version &lt; 2.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(@dimensionURL and not(exists(./unitsml:DimensionReference))) or (not(@dimensionURL) and exists(./unitsml:DimensionReference)) or (not(@dimensionURL) and not(exists(./unitsml:DimensionReference))) ">
+			<xsd:annotation>
+				<xsd:documentation>Allow a reference to a Dimension via the dimensionURL or a
+					DimensionReference element but not both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<!--     === Dimension specific Types ===-->
 	<xsd:complexType name="DimensionSetType">
@@ -802,6 +1292,21 @@ additive inverse of this number.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
+	<xsd:attribute name="domain" type="xsd:token" use="optional" inheritable="true">
+			<xsd:annotation>
+				<xsd:documentation>Sets the restricted domain for the entire
+					set.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:assert test="
+				if (exists(@domain)) then
+					empty(./unitsml:Dimension[@domain ne ../@domain])
+				else
+					true()">
+			<xsd:annotation>
+				<xsd:documentation>If a domain is given for a set, every member of the set must belong to the same domain.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<xsd:complexType name="DimensionType">
 		<xsd:annotation>
@@ -825,12 +1330,16 @@ additive inverse of this number.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
-		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute ref="xml:id" use="optional"/>
+		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
+		<xsd:attributeGroup ref="unitsml:timestamp"/>
 		<xsd:attribute name="dimensionless" type="xsd:boolean" use="optional" default="0">
 			<xsd:annotation>
 				<xsd:documentation>Boolean to designate that a quantity or unit is dimensionless.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+	<xsd:assert test="(@xml:id or (@domain and @key and @version))"/>
+		<xsd:assert test="(not(@domain) and not(@key) and not(@version)) or (@domain and @key and @version)"/>
 	</xsd:complexType>
 	<xsd:complexType name="LengthType">
 		<xsd:annotation>
@@ -944,6 +1453,21 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:sequence>
 			<xsd:element ref="unitsml:Prefix" maxOccurs="unbounded"/>
 		</xsd:sequence>
+	<xsd:attribute name="domain" type="xsd:token" use="optional" inheritable="true">
+			<xsd:annotation>
+				<xsd:documentation>Sets the restricted domain for the entire
+					set.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:assert test="
+				if (exists(@domain)) then
+					empty(./unitsml:Prefix[@domain ne ../@domain])
+				else
+					true()">
+			<xsd:annotation>
+				<xsd:documentation>If a domain is given for a set, every member of the set must belong to the same domain.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<xsd:complexType name="PrefixType">
 		<xsd:annotation>
@@ -953,7 +1477,10 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:element ref="unitsml:PrefixName" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:PrefixSymbol" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
-		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute ref="xml:id" use="optional"/>
+		<xsd:attribute name="domain" type="xsd:token" default="SI"/>
+		<xsd:attribute name="key" type="xsd:token" use="optional"/>
+		<xsd:attributeGroup ref="unitsml:timestamp"/>
 		<xsd:attribute name="prefixBase" default="10">
 			<xsd:annotation>
 				<xsd:documentation>The base of the prefix system, i.e., 10 (SI) or 2 (binary).</xsd:documentation>
@@ -970,6 +1497,17 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>The exponential power of the prefix with relation to the base.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+	<xsd:assert test="(@xml:id or (@domain and @key))">
+			<xsd:annotation>
+				<xsd:documentation>Require at least one identification type via xml:id or domain
+					and key duplett or both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert test="not(@key) or (@domain and @key)">
+			<xsd:annotation>
+				<xsd:documentation>Do not allow a partial reference</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
 	</xsd:complexType>
 	<!--     === General Types ===-->
 	<xsd:complexType name="NameType">
@@ -1096,4 +1634,42 @@ additive inverse of this number.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
+    <xsd:complexType name="KeyedReferenceType">
+        <xsd:annotation>
+            <xsd:documentation>Type for reference to an indexed object.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attributeGroup ref="unitsml:keyedReferenceAttributeGroup"/>
+    </xsd:complexType>
+    <xsd:complexType name="KeyedReferenceUnitWithPowerRationalType">
+        <xsd:complexContent>
+            <xsd:extension base="unitsml:KeyedReferenceType">
+                <xsd:attributeGroup ref="unitsml:powerRational"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="KeyedReferencePrefixType">
+        <xsd:annotation>
+            <xsd:documentation>Type for reference to a unit or quantity.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="domain" type="xsd:token" default="SI">
+            <xsd:annotation>
+                <xsd:documentation>Domain of the referenced quantity.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="key" type="xsd:token" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Key of the referenced quantity.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="version" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Version of the referenced quantity.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:positiveInteger">
+                    <xsd:minInclusive value="1"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+    </xsd:complexType>
 </xsd:schema>

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -1,0 +1,1059 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Units Markup language (UnitsML) Schema
+    Website: http://unitsml.nist.gov
+    Version History: http://unitsml.nist.gov/Schema/schema_changes.txt
+
+Copyright (C) OASIS Open 2006 - 2011. All Rights Reserved.
+
+All capitalized terms in the following text have the meanings
+assigned to them in the OASIS Intellectual Property Rights Policy
+(the "OASIS IPR Policy"). The full Policy may be found at the OASIS
+website.
+
+This document and translations of it may be copied and furnished
+to others, and derivative works that comment on or otherwise explain
+it or assist in its implementation may be prepared, copied, published,
+and distributed, in whole or in part, without restriction of any
+kind, provided that the above copyright notice and this section
+are included on all such copies and derivative works. However, this
+document itself may not be modified in any way, including by removing
+the copyright notice or references to OASIS, except as needed for
+the purpose of developing any document or deliverable produced by
+an OASIS Technical Committee (in which case the rules applicable
+to copyrights, as set forth in the OASIS IPR Policy, must be
+followed) or as required to translate it into languages other than
+English.
+
+The limited permissions granted above are perpetual and will not
+be revoked by OASIS or its successors or assigns.
+
+This document and the information contained herein is provided on
+an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR
+ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE.
+
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://schema.unitsml.org/unitsml/1.0" targetNamespace="https://schema.unitsml.org/unitsml/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+	<!--=== Root-Node of an UnitsML document ===-->
+	<xsd:element name="UnitsML" type="UnitsMLType">
+		<xsd:annotation>
+			<xsd:documentation>Container for UnitsML units, quantities, and prefixes.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnitsMLType">
+		<xsd:annotation>
+			<xsd:documentation>ComplexType for the root element of an UnitsML document.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="UnitSet" minOccurs="0"/>
+			<xsd:element ref="CountedItemSet" minOccurs="0"/>
+			<xsd:element ref="QuantitySet" minOccurs="0"/>
+			<xsd:element ref="DimensionSet" minOccurs="0"/>
+			<xsd:element ref="PrefixSet" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--=== Global document elements ===-->
+	<!--     === Unit elements ===-->
+	<xsd:element name="UnitSet" type="UnitSetType">
+		<xsd:annotation>
+			<xsd:documentation>Container for units. Use in UnitsML container or directly incorporate into a host schema.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Unit" type="UnitType">
+		<xsd:annotation>
+			<xsd:documentation>Element for describing units. Use in containers UnitSet or directly incorporate into a host schema.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitSystem" type="SystemType">
+		<xsd:annotation>
+			<xsd:documentation>Container for describing the system of units.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitName" type="NameType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the unit name.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitSymbol" type="SymbolType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing various unit symbols.  Examples include Aring (ASCII), Å (HTML).</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitVersionHistory" type="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="CodeListValue" type="CodeListValueType">
+		<xsd:annotation>
+			<xsd:documentation>Element for listing the unit code value from a specific code list.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="RootUnits" type="RootUnitsType">
+		<xsd:annotation>
+			<xsd:documentation>Container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered root units.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="EnumeratedRootUnit" type="EnumeratedRootUnitType">
+		<xsd:annotation>
+			<xsd:documentation>Element for a root unit (from an extensive enumerated list) allowing an optional prefix and power. E.g., mm^2</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ExternalRootUnit" type="ExternalRootUnitType">
+		<xsd:annotation>
+			<xsd:documentation>Element for those special cases where the root unit needed is not included in the enumerated list in the above element.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Conversions" type="ConversionsType">
+		<xsd:annotation>
+			<xsd:documentation>Container for providing conversion information to other units.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Float64ConversionFrom" type="Float64ConversionFromType">
+		<xsd:annotation>
+			<xsd:documentation>Element for providing factors for a conversion equation from another unit; y = d + ((b / c) (x + a))</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConversionNote" type="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element for descriptive information.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="SpecialConversionFrom" type="SpecialConversionFromType">
+		<xsd:annotation>
+			<xsd:documentation>Element for providing unit conversion information for conversions that are more complex than the Float64ConversionFrom linear equation.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="WSDLConversionFrom" type="WSDLConversionFromType">
+		<xsd:annotation>
+			<xsd:documentation>Element for providing conversion based on SOAP/WSDL calls to a remote server.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="WSDLDescription" type="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the WSDL service.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConversionDescription" type="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element for a description of the SpecialConversionFrom.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantityReference" type="ReferenceType">
+		<xsd:annotation>
+			<xsd:documentation>Element for all quantities that can be expressed using this unit.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitDefinition" type="DefinitionType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the definition of the unit.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitHistory" type="HistoryType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the historical development of the unit.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitRemark" type="RemarkType">
+		<xsd:annotation>
+			<xsd:documentation>Element as a placeholder for additional information.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!--     === Counted item elements ===-->
+	<xsd:element name="CountedItemSet" type="CountedItemSetType">
+		<xsd:annotation>
+			<xsd:documentation>Container for items that are counted and are (in practice) combined with scientific units of measure.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="CountedItem" type="CountedItemType">
+		<xsd:annotation>
+			<xsd:documentation>Container for a single counted item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ItemName" type="NameType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the item name(s).</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ItemSymbol" type="SymbolType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing symbols for the item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ItemVersionHistory" type="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element for descriptive information, including version changes to the item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ItemDefinition" type="DefinitionType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the definition of the item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ItemHistory" type="HistoryType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the historical development of the item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ItemRemark" type="RemarkType">
+		<xsd:annotation>
+			<xsd:documentation>Element as a placeholder for additional information.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!--     === Quantity elements ===-->
+	<xsd:element name="QuantitySet" type="QuantitySetType">
+		<xsd:annotation>
+			<xsd:documentation>Container for quantities.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Quantity" type="QuantityType">
+		<xsd:annotation>
+			<xsd:documentation>Element for describing quantities and referencing corresponding units. Use in container or directly incorporate into a host schema.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantityName" type="NameType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the quantity name.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantitySymbol" type="SymbolType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="UnitReference" type="ReferenceType">
+		<xsd:annotation>
+			<xsd:documentation>Element for referencing a unit of measure from within the Quantity element.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantityVersionHistory" type="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantityDefinition" type="DefinitionType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the definition of the quantity.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantityHistory" type="HistoryType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the historical development of the quantity.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="QuantityRemark" type="RemarkType">
+		<xsd:annotation>
+			<xsd:documentation>Element as a placeholder for additional information.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!--     === Dimension elements ===-->
+	<xsd:element name="DimensionSet" type="DimensionSetType">
+		<xsd:annotation>
+			<xsd:documentation>Container for dimensions.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Dimension" type="DimensionType">
+		<xsd:annotation>
+			<xsd:documentation>Element to express the dimension of a unit or quantity in terms of the SI base quantities length, mass, time, electric current, thermodynamic temperature, amount of substance, and luminous intensity.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Length" type="LengthType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity length.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Mass" type="MassType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity mass.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Time" type="TimeType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity time.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ElectricCurrent" type="ElectricCurrentType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity electric current.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ThermodynamicTemperature" type="ThermodynamicTemperatureType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity thermodynamic temerature.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="AmountOfSubstance" type="AmountOfSubstanceType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity amount of substance.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="LuminousIntensity" type="LuminousIntensityType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity luminous intensity.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="PlaneAngle" type="PlaneAngleType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of the quantity plane angle.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Item" type="ItemType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the dimension of any item. Note: this element is meant to be used to allow counted items to be included in the dimensioning of a derived quantity, e.g., electrons per time; usage of this element does not conform to the SI description of the dimension of a quantity in terms of seven base quantities.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!--     === Prefix elements ===-->
+	<xsd:element name="PrefixSet" type="PrefixSetType">
+		<xsd:annotation>
+			<xsd:documentation>Container for prefixes.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Prefix" type="PrefixType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing information about a prefix.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="PrefixName" type="NameType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the prefix name.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="PrefixSymbol" type="SymbolType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing prefix symbols.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!--=== Attribute groups (global) ===-->
+	<xsd:attributeGroup name="initialUnit">
+		<xsd:annotation>
+			<xsd:documentation>URI indicating the unitID of the starting unit for the conversion. For units which are defined in the same document, the URI should consist of a pound sign (#) followed by the ID value.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="initialUnit" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>URI indicating the unitID of the starting unit for the conversion. For units which are defined in the same document, the URI should consist of a pound sign (#) followed by the ID value.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="sourceName">
+		<xsd:annotation>
+			<xsd:documentation>Name of relevant publication.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="sourceName" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Name of relevant publication.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="sourceURL">
+		<xsd:annotation>
+			<xsd:documentation>Relevant URL for available information.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="sourceURL" type="xsd:anyURI" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Relevant URL for available information.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="powerRational">
+		<xsd:annotation>
+			<xsd:documentation>An exponent of the unit, specified as powerNumerator and powerDenominator.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="powerNumerator" type="xsd:byte" use="optional" default="1">
+			<xsd:annotation>
+				<xsd:documentation>An integer exponent of the unit.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="powerDenominator" type="xsd:byte" use="optional" default="1">
+			<xsd:annotation>
+				<xsd:documentation>An integer value divided into the powerNumerator to create a non integer exponent of a unit.  For example 1/2.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="prefix">
+		<xsd:annotation>
+			<xsd:documentation>Prefix identifier; e.g., m, k, M, G.  [Enumeration order is by prefix magnitude (Y to y) followed by binary prefixes.]</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="prefix">
+			<xsd:annotation>
+				<xsd:documentation>Prefix identifier; e.g., m, k, M, G.  [Enumeration order is by prefix magnitude (Y to y) followed by binary prefixes.]</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<boilerplate href="prefixes.xml"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="dimensionURL">
+		<xsd:annotation>
+			<xsd:documentation>URL to a representation of the unit or quantity in terms of the 7 SI base dimensions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="dimensionURL" type="xsd:anyURI">
+			<xsd:annotation>
+				<xsd:documentation>URL to a representation of the unit or quantity in terms of the 7 SI base dimensions.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<!--=== Type definitions ===-->
+	<!--     === Unit specific Types ===-->
+	<xsd:complexType name="UnitSetType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the unit container.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Unit" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for describing units. Use in containers UnitSet or directly incorporate into a host schema.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="UnitType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the unit.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="UnitSystem" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Container for describing the system(s) of units.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="UnitName" maxOccurs="unbounded"/>
+			<xsd:element ref="UnitSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="RootUnits" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered root units.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="Conversions" minOccurs="0"/>
+			<xsd:element ref="QuantityReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="UnitVersionHistory" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="UnitDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="UnitHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="UnitRemark" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute name="timeStamp" type="xsd:dateTime">
+			<xsd:annotation>
+				<xsd:documentation>Used to indicate the version of the unit output from the Units Database. Changes in the time-stamp are made if a substantive change has been made to the unit, such as a change in the unit definition or changes in conversion factors.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="dimensionURL">
+			<xsd:annotation>
+				<xsd:documentation>Reference to a representation of the unit or quantity in terms of the 7 SI base dimensions.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attributeGroup>
+	</xsd:complexType>
+	<xsd:complexType name="CodeListValueType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for listing the unit code value from a specific code list.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="unitCodeValue" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The code associated for this unit in a specific code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="codeListName" type="xsd:normalizedString">
+			<xsd:annotation>
+				<xsd:documentation>The name of the code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="codeListVersion" type="xsd:token">
+			<xsd:annotation>
+				<xsd:documentation>The version of the code list containing the unit code.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="locationURL" type="xsd:anyURI">
+			<xsd:annotation>
+				<xsd:documentation>Suggested retrieval location for this version of the code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="organizationName" type="xsd:normalizedString">
+			<xsd:annotation>
+				<xsd:documentation>Organization responsible for publication and/or maintenance of the code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="organizationURI" type="xsd:anyURI">
+			<xsd:annotation>
+				<xsd:documentation>URI for organization responsible for the code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute ref="xml:lang">
+			<xsd:annotation>
+				<xsd:documentation>Primary language of the element and/or its attributes. [See RFC 4646, RFC 4647 and ISO 639.]</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="RootUnitsType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered base units.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="EnumeratedRootUnit" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for a root unit (from an extensive enumerated list) allowing an optional prefix and power. E.g., mm^2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExternalRootUnit" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for those special cases where the root unit needed is not included in the enumerated list in the above element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="EnumeratedRootUnitType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for a root unit (from an extensive enumerated list) allowing an optional prefix and power. E.g., mm^2</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="unit" use="required">
+			<xsd:annotation>
+				<xsd:documentation>Unit identifier; the enumerated list is basically English unit names in lowercase, with a few upper case exceptions, e.g., 32F, mmHg, pH.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<boilerplate href="units.xml"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="sourceURL"/>
+		<xsd:attributeGroup ref="prefix">
+			<xsd:annotation>
+				<xsd:documentation>Prefix identifier; e.g., m, k, M, G. [Enumeration order is by prefix magnitude (Y to y) followed by binary prefixes.]</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attributeGroup>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="ExternalRootUnitType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for those special cases where the root unit needed is not included in the enumerated list in the above element.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="unit" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>URI to identify the unit.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="sourceURL">
+			<xsd:annotation>
+				<xsd:documentation>URI identifying the source and possibly the definition of the unit.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attributeGroup>
+		<xsd:attribute name="annotation" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Optional unit annotation; e.g., a unit name if the unit identifier above is an uncommon code.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute ref="xml:lang"/>
+		<xsd:attributeGroup ref="prefix"/>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="ConversionsType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the container for providing conversion information to other units.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Float64ConversionFrom" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for providing factors for a conversion equation from another unit; y = d + ((b / c) (x + a)). Note: The related "conversion to" equation is a simple inversion of the above equation; i.e., x = ((c / b) (y - d)) - a.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="SpecialConversionFrom" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for describing a conversion that cannot be described by the linear expression in the element Float64ConversionFrom.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="WSDLConversionFrom" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for providing conversion based on SOAP/WSDL calls to a remote server.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="Float64ConversionFromType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for providing factors for a conversion equation from another unit; y = d + ((b / c) (x + a))</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="ConversionNote" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attributeGroup ref="initialUnit"/>
+		<xsd:attribute name="initialAddend" type="xsd:double" default="0">
+			<xsd:annotation>
+				<xsd:documentation>Number to be added at the start of the conversion (prior to multiplication or division) [factor 'a' in equation].</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="initialAddendDecimalPlace" type="xsd:byte">
+			<xsd:annotation>
+				<xsd:documentation>Indicates the position of the least
+significant digit (in decimal) of
+the initialAddend; the position of
+this digit is given by ten to
+additive inverse of this number.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="multiplicand" type="xsd:double" default="1">
+			<xsd:annotation>
+				<xsd:documentation>Number by which to multiply sum of initial addend and initial value [factor 'b' in equation].</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="multiplicandDigits" type="xsd:unsignedByte">
+			<xsd:annotation>
+				<xsd:documentation>Number of significant digits in the multiplicand value.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="divisor" type="xsd:double" default="1">
+			<xsd:annotation>
+				<xsd:documentation>Divisor to be applied to the value at the same time as the multiplicand [factor 'c' in equation].</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="divisorDigits" type="xsd:unsignedByte">
+			<xsd:annotation>
+				<xsd:documentation>Number of significant digits in the divisor value.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="finalAddend" type="xsd:double" default="0">
+			<xsd:annotation>
+				<xsd:documentation>Number to be added at the end of the conversion [factor 'd' in equation].</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="finalAddendDecimalPlace" type="xsd:byte">
+			<xsd:annotation>
+				<xsd:documentation>Indicates the position of the least
+significant digit (in decimal) of
+the finalAddend; the position of
+this digit is given by ten to
+additive inverse of this number.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="exact" type="xsd:boolean" default="false">
+			<xsd:annotation>
+				<xsd:documentation>Indicates if the conversion is exact.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpecialConversionFromType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for providing unit conversion information for conversions that are more complex than the Float64ConversionFrom linear equation.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="ConversionDescription" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Description of the conversion.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute name="conversionURL" type="xsd:anyURI">
+			<xsd:annotation>
+				<xsd:documentation>URL for external description of the conversion or for an online convertor.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="initialUnit"/>
+	</xsd:complexType>
+	<xsd:complexType name="WSDLConversionFromType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for providing unit conversion information for conversions that are more complex than the Float64ConversionFrom linear equation.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="WSDLDescription" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Description of the service.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attributeGroup ref="initialUnit"/>
+		<xsd:attribute name="wsdlURL" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>URL for external WSDL definition file.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<!--     === CountedItem specific Types ===-->
+	<xsd:complexType name="CountedItemSetType">
+		<xsd:annotation>
+			<xsd:documentation>Type for a set of counted items.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="CountedItem" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CountedItemType">
+		<xsd:annotation>
+			<xsd:documentation>Type for a single counted item.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="ItemName" maxOccurs="unbounded"/>
+			<xsd:element ref="ItemSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ItemVersionHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ItemHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ItemRemark" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+	</xsd:complexType>
+	<!--     === Quantity specific Types ===-->
+	<xsd:complexType name="QuantitySetType">
+		<xsd:annotation>
+			<xsd:documentation>Type for quantity container.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Quantity" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="QuantityType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the quantity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="QuantityName" maxOccurs="unbounded"/>
+			<xsd:element ref="QuantitySymbol" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="UnitReference" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for specifying particular units associated with the quantity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="QuantityVersionHistory" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for descriptive information, including version changes to the quantity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="QuantityDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="QuantityHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="QuantityRemark" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute name="quantityType" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Type of the quantity.  For example base or derived.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="base"/>
+					<xsd:enumeration value="derived"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+			<!-- REVISE -->
+		</xsd:attribute>
+		<xsd:attributeGroup ref="dimensionURL"/>
+	</xsd:complexType>
+	<!--     === Dimension specific Types ===-->
+	<xsd:complexType name="DimensionSetType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the dimension container.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Dimension" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element to express a unit or quantity in terms of the SI base quantities length, mass, time, electric current, thermodynamic temperature, amount of substance, and luminous intensity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DimensionType">
+		<xsd:annotation>
+			<xsd:documentation>Type for dimension.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence maxOccurs="unbounded">
+			<xsd:annotation>
+				<xsd:documentation>This unbounded sequence allows any order of any number of elements; e.g., L^1 Â· L^-1.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:element ref="Length" minOccurs="0"/>
+			<xsd:element ref="Mass" minOccurs="0"/>
+			<xsd:element ref="Time" minOccurs="0"/>
+			<xsd:element ref="ElectricCurrent" minOccurs="0"/>
+			<xsd:element ref="ThermodynamicTemperature" minOccurs="0"/>
+			<xsd:element ref="AmountOfSubstance" minOccurs="0"/>
+			<xsd:element ref="LuminousIntensity" minOccurs="0"/>
+			<xsd:element ref="PlaneAngle" minOccurs="0"/>
+			<xsd:element ref="Item" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element containing the dimension of any item. Note: this element is meant to be used to allow counted items to be included in the dimensioning of a derived quantity, e.g., electrons per time; usage of this element does not conform to the SI description of the dimension of a quantity in terms of seven base quantities.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute name="dimensionless" type="xsd:boolean" use="optional" default="0">
+			<xsd:annotation>
+				<xsd:documentation>Boolean to designate that a quantity or unit is dimensionless.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="LengthType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity length.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="L">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity length.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="MassType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity mass.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="M">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity mass.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="TimeType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity time.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="T">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity time.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="ElectricCurrentType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity electric current.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="I">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity electric current.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="ThermodynamicTemperatureType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity thermodynamic temperature.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="Θ">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity thermodynamic temperature.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="AmountOfSubstanceType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity amount of substance.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="N">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity amount of substance.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="LuminousIntensityType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity luminous intensity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token" use="optional" fixed="J">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity luminous intensity.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="PlaneAngleType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity plane angle.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="symbol" type="xsd:token">
+			<xsd:annotation>
+				<xsd:documentation>Symbol of the quantity plane angle.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<xsd:complexType name="ItemType">
+		<xsd:annotation>
+			<xsd:documentation>Type of the quantity represented by a counted item, e.g., electron</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="itemURL" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>Unique URL for identifying or describing the item.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="itemSymbol" type="xsd:token">
+			<xsd:annotation>
+				<xsd:documentation>Symbol for the item.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="powerRational"/>
+	</xsd:complexType>
+	<!--     === Prefix specific Types ===-->
+	<xsd:complexType name="PrefixSetType">
+		<xsd:annotation>
+			<xsd:documentation>Type for container for prefixes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Prefix" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PrefixType">
+		<xsd:annotation>
+			<xsd:documentation>Type for element for describing prefixes. Use in container PrefixSet.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="PrefixName" maxOccurs="unbounded"/>
+			<xsd:element ref="PrefixSymbol" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="required"/>
+		<xsd:attribute name="prefixBase" default="10">
+			<xsd:annotation>
+				<xsd:documentation>The base of the prefix system, i.e., 10 (SI) or 2 (binary).</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:byte">
+					<xsd:enumeration value="10"/>
+					<xsd:enumeration value="2"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="prefixPower" type="xsd:byte">
+			<xsd:annotation>
+				<xsd:documentation>The exponential power of the prefix with relation to the base.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<!--     === General Types ===-->
+	<xsd:complexType name="NameType">
+		<xsd:annotation>
+			<xsd:documentation>Type for name.  Used for names in units, quantities, and prefixes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:token">
+				<xsd:attribute ref="xml:lang"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SystemType">
+		<xsd:annotation>
+			<xsd:documentation>Type for unit system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:token" use="required">
+			<xsd:annotation>
+				<xsd:documentation>Name of the unit system.   For example, SI, inch-pound, CGS, and MKS.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="type" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Description of the unit relative to the unit system.  Examples are SI_base and non-SI_not_acceptable.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute ref="xml:lang"/>
+	</xsd:complexType>
+	<xsd:complexType name="SymbolType" mixed="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for symbols.  Used in units, quantities, and prefixes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence minOccurs="0" maxOccurs="unbounded">
+			<xsd:any processContents="skip" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:lang"/>
+		<xsd:attribute name="type" use="required">
+			<xsd:annotation>
+				<xsd:documentation>Type of symbol representation.  Examples include ASCII, unicode, HTML, and MathML.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:token">
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:token">
+							<xsd:enumeration value="ASCII"/>
+							<xsd:enumeration value="Unicode"/>
+							<xsd:enumeration value="LaTeX"/>
+							<xsd:enumeration value="HTML"/>
+							<xsd:enumeration value="MathML"/>
+							<xsd:enumeration value="SVG"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:union>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Type for notes.  Used in units and conversion factors.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attribute ref="xml:lang"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DefinitionType">
+		<xsd:annotation>
+			<xsd:documentation>Type for definition.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attributeGroup ref="sourceURL"/>
+				<xsd:attributeGroup ref="sourceName"/>
+				<xsd:attribute ref="xml:lang"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="HistoryType">
+		<xsd:annotation>
+			<xsd:documentation>Type for history.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attributeGroup ref="sourceURL"/>
+				<xsd:attributeGroup ref="sourceName"/>
+				<xsd:attribute ref="xml:lang"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RemarkType">
+		<xsd:annotation>
+			<xsd:documentation>Type for remark.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attributeGroup ref="sourceURL"/>
+				<xsd:attributeGroup ref="sourceName"/>
+				<xsd:attribute ref="xml:lang">
+					<xsd:annotation>
+						<xsd:documentation>Primary language of the element and/or its attributes. [See RFC 4646, RFC 4647 and ISO 639.]</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ReferenceType">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to a unit or quantity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="url" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>URL to the reference item.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" type="xsd:token" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Name of the referenced item.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute ref="xml:lang">
+			<xsd:annotation>
+				<xsd:documentation>Primary language of the element and/or its attributes. [See RFC 4646, RFC 4647 and ISO 639.]</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+</xsd:schema>

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -51,11 +51,13 @@ PURPOSE.
 	xmlns:ver="http://www.w3.org/2007/XMLSchema-versioning"
 	xmlns:vc="urn:ietf:params:xml:ns:vcard-4.0"
 	xmlns:mathml="http://www.w3.org/1998/Math/MathML"
+	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
 	elementFormDefault="qualified"
 	attributeFormDefault="unqualified" version="2.0" ver:minVersion="1.1">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
     <xsd:import namespace="urn:ietf:params:xml:ns:vcard-4.0" schemaLocation="https://www.iana.org/assignments/xml-registry/schema/vcard-4.0.xsd"/>
 	<xsd:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="https://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd"/>
+	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/xmldsig-core-schema.xsd"/>
 	<!--=== Root-Node of an UnitsML document ===-->
 	<xsd:element name="UnitsML" type="unitsml:UnitsMLType">
 		<xsd:annotation>
@@ -188,6 +190,7 @@ PURPOSE.
 		    <xsd:element ref="unitsml:DimensionSet" minOccurs="0" maxOccurs="unbounded"/>
 		    <xsd:element ref="unitsml:PrefixSet" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ConstantSet" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ds:Signature" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	    <xsd:assert test="
 	        every $var in unitsml:UnitSet/unitsml:Unit[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -50,10 +50,12 @@ PURPOSE.
 	targetNamespace="https://schema.unitsml.org/unitsml/2.0"
 	xmlns:ver="http://www.w3.org/2007/XMLSchema-versioning"
 	xmlns:vc="urn:ietf:params:xml:ns:vcard-4.0"
+	xmlns:mathml="http://www.w3.org/1998/Math/MathML"
 	elementFormDefault="qualified"
 	attributeFormDefault="unqualified" version="2.0" ver:minVersion="1.1">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
     <xsd:import namespace="urn:ietf:params:xml:ns:vcard-4.0" schemaLocation="https://www.iana.org/assignments/xml-registry/schema/vcard-4.0.xsd"/>
+	<xsd:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="https://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd"/>
 	<!--=== Root-Node of an UnitsML document ===-->
 	<xsd:element name="UnitsML" type="unitsml:UnitsMLType">
 		<xsd:annotation>
@@ -363,20 +365,31 @@ PURPOSE.
 			<xsd:documentation>Element containing the unit name.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitSymbol" type="unitsml:SymbolType">
+	<xsd:element name="UnitSymbol">
 		<xsd:annotation>
 			<xsd:documentation>Element containing various unit symbols.  Examples include Aring (ASCII), Å (HTML).</xsd:documentation>
 		</xsd:annotation>
+		<xsd:alternative test="@type eq 'ASCII'" type="unitsml:ASCIIContent"/>
+		<xsd:alternative test="@type eq 'Unicode'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'LaTeX'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'HTML'" type="unitsml:HTMLContent"/>
+		<xsd:alternative test="@type eq 'MathML'" type="unitsml:MathMLContent"/>
+		<xsd:alternative test="@type eq 'SVG'" type="unitsml:HTMLContent"/> <!-- Maybe use the offical DTD or convert it to XSD -->
+		<xsd:alternative test="@type eq 'D-SI'" type="unitsml:D-SI"/>
+		<xsd:alternative test="@type eq 'UCUM'" type="unitsml:ASCIIType"/>
+		<xsd:alternative type="unitsml:UnicodeContent"/>
 	</xsd:element>
 	<xsd:element name="UnitVersionHistory" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="CodeListValue" type="unitsml:CodeListValueType">
+	<xsd:element name="CodeListValue">
 		<xsd:annotation>
-			<xsd:documentation>Element for listing the unit code value from a specific code list.</xsd:documentation>
+			<xsd:documentation>Element for listing the code value from a specific code list.</xsd:documentation>
 		</xsd:annotation>
+		<xsd:alternative test="@IRDI" type="unitsml:IRDICodeListValueType"/>
+		<xsd:alternative type="unitsml:CodeListValueType"/>
 	</xsd:element>
 	<xsd:element name="RootUnits" type="unitsml:RootUnitsType">
 		<xsd:annotation>
@@ -467,10 +480,19 @@ PURPOSE.
 			<xsd:documentation>Element containing the item name(s).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemSymbol" type="unitsml:SymbolType">
+	<xsd:element name="ItemSymbol">
 		<xsd:annotation>
 			<xsd:documentation>Element containing symbols for the item.</xsd:documentation>
 		</xsd:annotation>
+		<xsd:alternative test="@type eq 'ASCII'" type="unitsml:ASCIIContent"/>
+		<xsd:alternative test="@type eq 'Unicode'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'LaTeX'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'HTML'" type="unitsml:HTMLContent"/>
+		<xsd:alternative test="@type eq 'MathML'" type="unitsml:MathMLContent"/>
+		<xsd:alternative test="@type eq 'SVG'" type="unitsml:HTMLContent"/> <!-- Maybe use the offical DTD or convert it to XSD -->
+		<xsd:alternative test="@type eq 'D-SI'" type="unitsml:D-SI"/>
+		<xsd:alternative test="@type eq 'UCUM'" type="unitsml:ASCIIType"/>
+		<xsd:alternative type="unitsml:UnicodeContent"/>
 	</xsd:element>
 	<xsd:element name="ItemVersionHistory" type="unitsml:NoteType">
 		<xsd:annotation>
@@ -514,10 +536,19 @@ PURPOSE.
 			<xsd:documentation>Element containing the quantity name.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantitySymbol" type="unitsml:SymbolType">
+	<xsd:element name="QuantitySymbol">
 		<xsd:annotation>
 			<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
 		</xsd:annotation>
+		<xsd:alternative test="@type eq 'ASCII'" type="unitsml:ASCIIContent"/>
+		<xsd:alternative test="@type eq 'Unicode'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'LaTeX'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'HTML'" type="unitsml:HTMLContent"/>
+		<xsd:alternative test="@type eq 'MathML'" type="unitsml:MathMLContent"/>
+		<xsd:alternative test="@type eq 'SVG'" type="unitsml:HTMLContent"/> <!-- Maybe use the offical DTD or convert it to XSD -->
+		<xsd:alternative test="@type eq 'D-SI'" type="unitsml:D-SI"/>
+		<xsd:alternative test="@type eq 'UCUM'" type="unitsml:ASCIIType"/>
+		<xsd:alternative type="unitsml:UnicodeContent"/>
 	</xsd:element>
 	<xsd:element name="QuantityVersionHistory" type="unitsml:NoteType">
 		<xsd:annotation>
@@ -611,13 +642,47 @@ PURPOSE.
 			<xsd:documentation>Element containing the prefix name.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PrefixSymbol" type="unitsml:SymbolType">
+	<xsd:element name="PrefixSymbol">
 		<xsd:annotation>
 			<xsd:documentation>Element containing prefix symbols.</xsd:documentation>
 		</xsd:annotation>
+		<xsd:alternative test="@type eq 'ASCII'" type="unitsml:ASCIIContent"/>
+		<xsd:alternative test="@type eq 'Unicode'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'LaTeX'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'HTML'" type="unitsml:HTMLContent"/>
+		<xsd:alternative test="@type eq 'MathML'" type="unitsml:MathMLContent"/>
+		<xsd:alternative test="@type eq 'SVG'" type="unitsml:HTMLContent"/> <!-- Maybe use the offical DTD or convert it to XSD -->
+		<xsd:alternative test="@type eq 'D-SI'" type="unitsml:D-SI"/>
+		<xsd:alternative test="@type eq 'UCUM'" type="unitsml:ASCIIType"/>
+		<xsd:alternative type="unitsml:UnicodeContent"/>
 	</xsd:element>
 	<!--=== Attribute groups (global) ===-->
-    <xsd:attributeGroup name="timestamp">
+    <xsd:attributeGroup name="type">
+		<xsd:annotation>
+			<xsd:documentation>Type of symbol representation. Examples include ASCII, unicode,
+				HTML, and MathML.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="type" use="required">
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:token">
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:token">
+							<xsd:enumeration value="ASCII"/>
+							<xsd:enumeration value="Unicode"/>
+							<xsd:enumeration value="LaTeX"/>
+							<xsd:enumeration value="HTML"/>
+							<xsd:enumeration value="MathML"/>
+							<xsd:enumeration value="SVG"/>
+							<xsd:enumeration value="D-SI"/>
+							<xsd:enumeration value="UCUM"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:union>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute ref="xml:lang"/>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="timestamp">
         <xsd:attribute name="timeStamp" type="xsd:dateTime">
             <xsd:annotation>
                 <xsd:documentation>Used to indicate the timepoint from which onward this element may be referenced.</xsd:documentation>
@@ -847,11 +912,11 @@ PURPOSE.
 	</xsd:complexType>
 	<xsd:complexType name="CodeListValueType">
 		<xsd:annotation>
-			<xsd:documentation>Type for the element for listing the unit code value from a specific code list.</xsd:documentation>
+			<xsd:documentation>Type for the element for listing the code value from a specific code list.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="unitCodeValue" type="xsd:string" use="required">
 			<xsd:annotation>
-				<xsd:documentation>The code associated for this unit in a specific code list.</xsd:documentation>
+				<xsd:documentation>The code associated for this element in a specific code list.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="codeListName" type="xsd:normalizedString">
@@ -861,7 +926,7 @@ PURPOSE.
 		</xsd:attribute>
 		<xsd:attribute name="codeListVersion" type="xsd:token">
 			<xsd:annotation>
-				<xsd:documentation>The version of the code list containing the unit code.</xsd:documentation>
+				<xsd:documentation>The version of the code list containing the code.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="locationURL" type="xsd:anyURI">
@@ -883,6 +948,60 @@ PURPOSE.
 		<xsd:attribute ref="xml:lang">
 			<xsd:annotation>
 				<xsd:documentation>Primary language of the element and/or its attributes. [See RFC 4646, RFC 4647 and ISO 639.]</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="IRDICodeListValueType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the element for listing the unit code value from a specific
+				code list.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="IRDI" type="unitsml:ASCIIType" use="required">
+			<!-- TODO: add validation -->
+			<xsd:annotation>
+				<xsd:documentation>The code associated for this unit in a specific code
+					list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="revision" type="xsd:positiveInteger" use="optional">
+			<!-- TODO: add validation -->
+			<xsd:annotation>
+				<xsd:documentation>The revision of the IRDI element.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="codeListName" type="xsd:normalizedString" fixed="IEC CDD">
+			<xsd:annotation>
+				<xsd:documentation>The name of the code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="codeListVersion" type="xsd:token">
+			<xsd:annotation>
+				<xsd:documentation>The version of the code list containing the unit
+					code.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="locationURL" type="xsd:anyURI" fixed="https://cdd.iec.ch/">
+			<xsd:annotation>
+				<xsd:documentation>Suggested retrieval location for this version of the code
+					list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="organizationName" type="xsd:normalizedString" fixed="International Electrotechnical Commission">
+			<xsd:annotation>
+				<xsd:documentation>Organization responsible for publication and/or maintenance of
+					the code list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="organizationURI" type="xsd:anyURI" fixed="https://iec.ch">
+			<xsd:annotation>
+				<xsd:documentation>URI for organization responsible for the code
+					list.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute ref="xml:lang">
+			<xsd:annotation>
+				<xsd:documentation>Primary language of the element and/or its attributes. [See RFC
+					4646, RFC 4647 and ISO 639.]</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
@@ -1139,6 +1258,7 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:sequence>
 			<xsd:element ref="unitsml:ItemName" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ItemSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ItemVersionHistory" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:ItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
@@ -1205,6 +1325,7 @@ additive inverse of this number.</xsd:documentation>
 					<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element ref="unitsml:CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:choice>
 				<xsd:sequence>
 					<xsd:element ref="unitsml:UnitReference" minOccurs="0" maxOccurs="unbounded">
@@ -1329,6 +1450,7 @@ additive inverse of this number.</xsd:documentation>
 					<xsd:documentation>Element containing the dimension of any item. Note: this element is meant to be used to allow counted items to be included in the dimensioning of a derived quantity, e.g., electrons per time; usage of this element does not conform to the SI description of the dimension of a quantity in terms of seven base quantities.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element ref="unitsml:CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="optional"/>
 		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
@@ -1476,6 +1598,7 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:sequence>
 			<xsd:element ref="unitsml:PrefixName" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:PrefixSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="optional"/>
 		<xsd:attribute name="domain" type="xsd:token" default="SI"/>
@@ -1510,6 +1633,72 @@ additive inverse of this number.</xsd:documentation>
 		</xsd:assert>
 	</xsd:complexType>
 	<!--     === General Types ===-->
+	<xsd:complexType name="ASCIIContent">
+		<xsd:simpleContent>
+			<xsd:extension base="unitsml:ASCIIType">
+				<xsd:attributeGroup ref="unitsml:type"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="UnicodeContent">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attributeGroup ref="unitsml:type"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="MathMLContent">
+		<xsd:choice>
+			<xsd:sequence>
+				<xsd:element ref="mathml:math"/>
+			</xsd:sequence>
+			<xsd:sequence>
+				<xsd:group minOccurs="0" maxOccurs="unbounded" ref="mathml:MathExpression"/>
+			</xsd:sequence>
+		</xsd:choice>
+		<xsd:attributeGroup ref="unitsml:type"/>
+	</xsd:complexType>
+	<xsd:complexType name="HTMLContent" mixed="true">
+		<xsd:sequence minOccurs="0" maxOccurs="unbounded">
+			<xsd:any processContents="skip" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attributeGroup ref="unitsml:type"/>
+	</xsd:complexType>
+	<xsd:complexType name="D-SI">
+		<xsd:simpleContent>
+			<xsd:extension base="unitsml:D-SIType">
+				<xsd:attributeGroup ref="unitsml:type"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="ASCIIType">
+		<xsd:annotation>
+			<xsd:documentation>This type can only contain ASCII characters.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:assertion test="matches($value, '^\p{IsBasicLatin}+$')"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="D-SIType">
+		<xsd:annotation>
+			<xsd:documentation>This type can only contain D-SI.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<!-- 
+				^((prefix)?(bipm_unit)(exponent)?)+$
+				where
+				prefix:
+				(\\(deca|hecto|kilo|mega|giga|tera|peta|exa|zetta|yotta|deci|centi|milli|micro|nano|pico|femto|atto|zepto|yocto))
+				
+				bipm_unit:
+				(\\(metre|kilogram|second|ampere|kelvin|mole|candela|one|day|hour|minute|degree|arcminute|arcsecond|gram|radian|steradian|hertz|newton|pascal|joule|watt|coulomb|volt|farad|ohm|siemens|weber|tesla|henry|degreecelsius|lumen|lux|becquerel|sievert|gray|katal|hectare|litre|tonne|electronvolt|dalton|astronomicalunit|neper|bel|decibel))
+				
+				exponent:
+				(\\tothe\{[+-]?([1-9][0-9]*|0\.5)})
+			-->
+			<xsd:assertion test="matches($value, '^((\\(deca|hecto|kilo|mega|giga|tera|peta|exa|zetta|yotta|deci|centi|milli|micro|nano|pico|femto|atto|zepto|yocto))?\\(metre|kilogram|second|ampere|kelvin|mole|candela|one|day|hour|minute|degree|arcminute|arcsecond|gram|radian|steradian|hertz|newton|pascal|joule|watt|coulomb|volt|farad|ohm|siemens|weber|tesla|henry|degreecelsius|lumen|lux|becquerel|sievert|gray|katal|hectare|litre|tonne|electronvolt|dalton|astronomicalunit|neper|bel|decibel)(\\tothe\{[+-]?([1-9][0-9]*|0\.5)})?)+$')"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 	<xsd:complexType name="NameType">
 		<xsd:annotation>
 			<xsd:documentation>Type for name.  Used for names in units, quantities, and prefixes.</xsd:documentation>
@@ -1535,34 +1724,6 @@ additive inverse of this number.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute ref="xml:lang"/>
-	</xsd:complexType>
-	<xsd:complexType name="SymbolType" mixed="true">
-		<xsd:annotation>
-			<xsd:documentation>Type for symbols.  Used in units, quantities, and prefixes.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence minOccurs="0" maxOccurs="unbounded">
-			<xsd:any processContents="skip" maxOccurs="unbounded"/>
-		</xsd:sequence>
-		<xsd:attribute ref="xml:lang"/>
-		<xsd:attribute name="type" use="required">
-			<xsd:annotation>
-				<xsd:documentation>Type of symbol representation.  Examples include ASCII, unicode, HTML, and MathML.</xsd:documentation>
-			</xsd:annotation>
-			<xsd:simpleType>
-				<xsd:union memberTypes="xsd:token">
-					<xsd:simpleType>
-						<xsd:restriction base="xsd:token">
-							<xsd:enumeration value="ASCII"/>
-							<xsd:enumeration value="Unicode"/>
-							<xsd:enumeration value="LaTeX"/>
-							<xsd:enumeration value="HTML"/>
-							<xsd:enumeration value="MathML"/>
-							<xsd:enumeration value="SVG"/>
-						</xsd:restriction>
-					</xsd:simpleType>
-				</xsd:union>
-			</xsd:simpleType>
-		</xsd:attribute>
 	</xsd:complexType>
 	<xsd:complexType name="NoteType">
 		<xsd:annotation>

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -49,9 +49,11 @@ PURPOSE.
 	xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0"
 	targetNamespace="https://schema.unitsml.org/unitsml/2.0"
 	xmlns:ver="http://www.w3.org/2007/XMLSchema-versioning"
+	xmlns:vc="urn:ietf:params:xml:ns:vcard-4.0"
 	elementFormDefault="qualified"
 	attributeFormDefault="unqualified" version="2.0" ver:minVersion="1.1">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+    <xsd:import namespace="urn:ietf:params:xml:ns:vcard-4.0" schemaLocation="https://www.iana.org/assignments/xml-registry/schema/vcard-4.0.xsd"/>
 	<!--=== Root-Node of an UnitsML document ===-->
 	<xsd:element name="UnitsML" type="unitsml:UnitsMLType">
 		<xsd:annotation>
@@ -63,14 +65,26 @@ PURPOSE.
 			<xsd:documentation>ComplexType for the root element of an UnitsML document.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="unitsml:UnitSet" minOccurs="0"/>
-			<xsd:element ref="unitsml:CountedItemSet" minOccurs="0"/>
-			<xsd:element ref="unitsml:QuantitySet" minOccurs="0"/>
-			<xsd:element ref="unitsml:DimensionSet" minOccurs="0"/>
-			<xsd:element ref="unitsml:PrefixSet" minOccurs="0"/>
+		    <xsd:element ref="unitsml:RegulatoryBody" minOccurs="0" maxOccurs="unbounded"/>
+		    <xsd:element ref="unitsml:UnitSet" minOccurs="0" maxOccurs="unbounded"/>
+		    <xsd:element ref="unitsml:CountedItemSet" minOccurs="0" maxOccurs="unbounded"/>
+		    <xsd:element ref="unitsml:QuantitySet" minOccurs="0" maxOccurs="unbounded"/>
+		    <xsd:element ref="unitsml:DimensionSet" minOccurs="0" maxOccurs="unbounded"/>
+		    <xsd:element ref="unitsml:PrefixSet" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	</xsd:complexType>
 	<!--=== Global document elements ===-->
+    <!--     === Regulatory body elements ===-->
+    <xsd:element name="RegulatoryBody" type="unitsml:RegulatoryBodyType">
+        <xsd:annotation>
+            <xsd:documentation>Data of the referenced regulatory bodies specifying an element describable by an instance document compliant with this schema.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:element name="NameOfEntity" type="unitsml:NameType">
+        <xsd:annotation>
+            <xsd:documentation>Element containing the unit name.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
 	<!--     === Unit elements ===-->
 	<xsd:element name="UnitSet" type="unitsml:UnitSetType">
 		<xsd:annotation>
@@ -413,6 +427,18 @@ PURPOSE.
 		</xsd:attribute>
 	</xsd:attributeGroup>
 	<!--=== Type definitions ===-->
+    <!--=== Regulatory Body specific Types ===-->
+    <xsd:complexType name="RegulatoryBodyType">
+        <xsd:annotation>
+            <xsd:documentation>Type for the regulatory body container.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element ref="unitsml:NameOfEntity" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="vc:vcard" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="Description" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="domainKey" type="xsd:token" use="optional"/>
+    </xsd:complexType>
 	<!--     === Unit specific Types ===-->
 	<xsd:complexType name="UnitSetType">
 		<xsd:annotation>

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -187,6 +187,7 @@ PURPOSE.
 		    <xsd:element ref="unitsml:QuantitySet" minOccurs="0" maxOccurs="unbounded"/>
 		    <xsd:element ref="unitsml:DimensionSet" minOccurs="0" maxOccurs="unbounded"/>
 		    <xsd:element ref="unitsml:PrefixSet" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ConstantSet" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	    <xsd:assert test="
 	        every $var in unitsml:UnitSet/unitsml:Unit[exists(@timeStamp) and exists(unitsml:PreviousVersion)] satisfies (
@@ -655,6 +656,61 @@ PURPOSE.
 		<xsd:alternative test="@type eq 'D-SI'" type="unitsml:D-SI"/>
 		<xsd:alternative test="@type eq 'UCUM'" type="unitsml:ASCIIType"/>
 		<xsd:alternative type="unitsml:UnicodeContent"/>
+	</xsd:element>
+	<!--=== Constant elements ===-->
+	<xsd:element name="ConstantSet" type="unitsml:ConstantSetType">
+		<xsd:annotation>
+			<xsd:documentation>Container for constants. Use in UnitsML container or directly incorporate
+				into a host schema.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="Constant" type="unitsml:ConstantType">
+		<xsd:annotation>
+			<xsd:documentation>Element for describing units. Use in containers UnitSet or directly
+				incorporate into a host schema.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConstantName" type="unitsml:NameType">
+		<xsd:annotation>
+			<xsd:documentation>Element containing the constants name.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConstantSymbol">
+		<xsd:annotation>
+			<xsd:documentation>Element containing various symbols representing the constant. Examples include e, pi.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:alternative test="@type eq 'ASCII'" type="unitsml:ASCIIContent"/>
+		<xsd:alternative test="@type eq 'Unicode'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'LaTeX'" type="unitsml:UnicodeContent"/>
+		<xsd:alternative test="@type eq 'HTML'" type="unitsml:HTMLContent"/>
+		<xsd:alternative test="@type eq 'MathML'" type="unitsml:MathMLContent"/>
+		<xsd:alternative test="@type eq 'SVG'" type="unitsml:HTMLContent"/> <!-- Maybe use the offical DTD or convert it to XSD -->
+		<xsd:alternative test="@type eq 'D-SI'" type="unitsml:D-SI"/>
+		<xsd:alternative test="@type eq 'UCUM'" type="unitsml:ASCIIType"/>
+		<xsd:alternative type="unitsml:UnicodeContent"/>
+	</xsd:element>
+	<xsd:element name="ConstantVersionHistory" type="unitsml:NoteType">
+		<xsd:annotation>
+			<xsd:documentation>Element for descriptive information, including version changes to the
+				constant.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConstantDefinition" type="unitsml:DefinitionType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the definition of the constant.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConstantHistory" type="unitsml:HistoryType">
+		<xsd:annotation>
+			<xsd:documentation>Element to describe the historical development of the
+				constant.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="ConstantRemark" type="unitsml:RemarkType">
+		<xsd:annotation>
+			<xsd:documentation>Element as a placeholder for additional
+				information.</xsd:documentation>
+		</xsd:annotation>
 	</xsd:element>
 	<!--=== Attribute groups (global) ===-->
     <xsd:attributeGroup name="type">
@@ -1629,6 +1685,119 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:assert test="not(@key) or (@domain and @key)">
 			<xsd:annotation>
 				<xsd:documentation>Do not allow a partial reference</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+	</xsd:complexType>
+	<!--=== Constant Types ===-->
+	<xsd:complexType name="ConstantSetType">
+		<xsd:annotation>
+			<xsd:documentation>Type for constant container.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="unitsml:Constant" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for describing constans. Use in containers ConstantSet or
+						directly incorporate into a host schema.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="domain" type="xsd:token" use="optional" inheritable="true">
+			<xsd:annotation>
+				<xsd:documentation>Sets the restricted domain for the entire
+					set.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:assert test="
+			if (exists(@domain)) then
+				empty(./unitsml:Quantity[@domain ne ../@domain])
+			else
+				true()">
+			<xsd:annotation>
+				<xsd:documentation>If a domain is given for a set, every member of the set must belong to the same domain.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+	</xsd:complexType>
+	<xsd:complexType name="ConstantType">
+		<xsd:annotation>
+			<xsd:documentation>Type for the constant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="RealValue">
+					<xsd:alternative test="exists(./unitsml:UnitReference)" type="xsd:double"/>
+					<xsd:alternative test="exists(./unitsml:CountableItemReference)" type="xsd:positiveInteger"/>
+					<xsd:alternative type="xsd:double"/>
+				</xsd:element>
+				<xsd:element name="ComplexValue">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="Value" type="xsd:double" maxOccurs="unbounded"/>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:choice>
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows a choice between a unit reference and a reference to
+						countable items. For example the Avogadro constant could be
+						defined as a constant of countable items.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:element ref="unitsml:UnitReference"/>
+				<xsd:element ref="unitsml:CountableItemReference"/>
+			</xsd:choice>
+			<xsd:element ref="unitsml:ConstantName" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ConstantSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ConstantVersionHistory" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Element for descriptive information, including version
+						changes to the constant.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0"
+				maxOccurs="1"/>
+			<xsd:element ref="unitsml:ConstantDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ConstantHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ConstantRemark" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute ref="xml:id" use="optional"/>
+		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
+		<xsd:attributeGroup ref="unitsml:timestamp"/>
+		<xsd:assert test="(@xml:id or (@domain and @key and @version))">
+			<xsd:annotation>
+				<xsd:documentation>Require at least one identification type via xml:id or domain,
+					key, version triplet or both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(not(@domain) and not(@key) and not(@version)) or (@domain and @key and @version)">
+			<xsd:annotation>
+				<xsd:documentation>Do not allow a partial reference</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert test="
+			if (@version and (@version > 1)) then
+				(exists(./unitsml:PreviousVersion) and (./unitsml:PreviousVersion/@version eq @version - 1) and (@key eq ./unitsml:PreviousVersion/@key) and (@domain eq ./unitsml:PreviousVersion/@domain))
+			else
+				not(exists(./unitsml:PreviousVersion))">
+			<xsd:annotation>
+				<xsd:documentation>If a version is specified then this constraint ensures a linear
+					version history of the unit. Does not allow for a PreviousVersion element when
+					version &lt; 2.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert
+			test="(@dimensionURL and not(exists(./unitsml:DimensionReference))) or (not(@dimensionURL) and exists(./unitsml:DimensionReference)) or (not(@dimensionURL) and not(exists(./unitsml:DimensionReference))) ">
+			<xsd:annotation>
+				<xsd:documentation>Allow a reference to a Dimension via the dimensionURL or a
+					DimensionReference element but not both.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:assert>
+		<xsd:assert test="exists(./unitsml:CountableItemReference) and not(exists(./unitsml:ComplexValue))">
+			<xsd:annotation>
+				<xsd:documentation>The cannot be a complex value with a countable item reference.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:assert>
 	</xsd:complexType>

--- a/templates/unitsml-v1.1.template
+++ b/templates/unitsml-v1.1.template
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+Development version:
+This schema is a non-standard compliant extension of the UnitsML OASIS
+standard and does not constitute or claim to constitute a standard itself
+nor is it endorsed or developed by OASIS. The UnitsML OASIS standard xsd 
+and additional information may be found at the following links:
+
+https://www.oasis-open.org/committees/download.php/44626/UnitsML-v1.0-csd04.xsd
+https://www.oasis-open.org/committees/download.php/43529/UnitsML-Guide-v1.0-wd01.pdf
+
    Units Markup language (UnitsML) Schema
     Website: http://unitsml.nist.gov
     Version History: http://unitsml.nist.gov/Schema/schema_changes.txt
@@ -36,10 +45,15 @@ ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
 PURPOSE.
 
 -->
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://schema.unitsml.org/unitsml/1.0" targetNamespace="https://schema.unitsml.org/unitsml/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0"
+	targetNamespace="https://schema.unitsml.org/unitsml/2.0"
+	xmlns:ver="http://www.w3.org/2007/XMLSchema-versioning"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified" version="2.0" ver:minVersion="1.1">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
 	<!--=== Root-Node of an UnitsML document ===-->
-	<xsd:element name="UnitsML" type="UnitsMLType">
+	<xsd:element name="UnitsML" type="unitsml:UnitsMLType">
 		<xsd:annotation>
 			<xsd:documentation>Container for UnitsML units, quantities, and prefixes.</xsd:documentation>
 		</xsd:annotation>
@@ -49,280 +63,280 @@ PURPOSE.
 			<xsd:documentation>ComplexType for the root element of an UnitsML document.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="UnitSet" minOccurs="0"/>
-			<xsd:element ref="CountedItemSet" minOccurs="0"/>
-			<xsd:element ref="QuantitySet" minOccurs="0"/>
-			<xsd:element ref="DimensionSet" minOccurs="0"/>
-			<xsd:element ref="PrefixSet" minOccurs="0"/>
+			<xsd:element ref="unitsml:UnitSet" minOccurs="0"/>
+			<xsd:element ref="unitsml:CountedItemSet" minOccurs="0"/>
+			<xsd:element ref="unitsml:QuantitySet" minOccurs="0"/>
+			<xsd:element ref="unitsml:DimensionSet" minOccurs="0"/>
+			<xsd:element ref="unitsml:PrefixSet" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
 	<!--=== Global document elements ===-->
 	<!--     === Unit elements ===-->
-	<xsd:element name="UnitSet" type="UnitSetType">
+	<xsd:element name="UnitSet" type="unitsml:UnitSetType">
 		<xsd:annotation>
 			<xsd:documentation>Container for units. Use in UnitsML container or directly incorporate into a host schema.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Unit" type="UnitType">
+	<xsd:element name="Unit" type="unitsml:UnitType">
 		<xsd:annotation>
 			<xsd:documentation>Element for describing units. Use in containers UnitSet or directly incorporate into a host schema.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitSystem" type="SystemType">
+	<xsd:element name="UnitSystem" type="unitsml:SystemType">
 		<xsd:annotation>
 			<xsd:documentation>Container for describing the system of units.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitName" type="NameType">
+	<xsd:element name="UnitName" type="unitsml:NameType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the unit name.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitSymbol" type="SymbolType">
+	<xsd:element name="UnitSymbol" type="unitsml:SymbolType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing various unit symbols.  Examples include Aring (ASCII), Å (HTML).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitVersionHistory" type="NoteType">
+	<xsd:element name="UnitVersionHistory" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="CodeListValue" type="CodeListValueType">
+	<xsd:element name="CodeListValue" type="unitsml:CodeListValueType">
 		<xsd:annotation>
 			<xsd:documentation>Element for listing the unit code value from a specific code list.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="RootUnits" type="RootUnitsType">
+	<xsd:element name="RootUnits" type="unitsml:RootUnitsType">
 		<xsd:annotation>
 			<xsd:documentation>Container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered root units.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="EnumeratedRootUnit" type="EnumeratedRootUnitType">
+	<xsd:element name="EnumeratedRootUnit" type="unitsml:EnumeratedRootUnitType">
 		<xsd:annotation>
 			<xsd:documentation>Element for a root unit (from an extensive enumerated list) allowing an optional prefix and power. E.g., mm^2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ExternalRootUnit" type="ExternalRootUnitType">
+	<xsd:element name="ExternalRootUnit" type="unitsml:ExternalRootUnitType">
 		<xsd:annotation>
 			<xsd:documentation>Element for those special cases where the root unit needed is not included in the enumerated list in the above element.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Conversions" type="ConversionsType">
+	<xsd:element name="Conversions" type="unitsml:ConversionsType">
 		<xsd:annotation>
 			<xsd:documentation>Container for providing conversion information to other units.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Float64ConversionFrom" type="Float64ConversionFromType">
+	<xsd:element name="Float64ConversionFrom" type="unitsml:Float64ConversionFromType">
 		<xsd:annotation>
 			<xsd:documentation>Element for providing factors for a conversion equation from another unit; y = d + ((b / c) (x + a))</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ConversionNote" type="NoteType">
+	<xsd:element name="ConversionNote" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element for descriptive information.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="SpecialConversionFrom" type="SpecialConversionFromType">
+	<xsd:element name="SpecialConversionFrom" type="unitsml:SpecialConversionFromType">
 		<xsd:annotation>
 			<xsd:documentation>Element for providing unit conversion information for conversions that are more complex than the Float64ConversionFrom linear equation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="WSDLConversionFrom" type="WSDLConversionFromType">
+	<xsd:element name="WSDLConversionFrom" type="unitsml:WSDLConversionFromType">
 		<xsd:annotation>
 			<xsd:documentation>Element for providing conversion based on SOAP/WSDL calls to a remote server.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="WSDLDescription" type="NoteType">
+	<xsd:element name="WSDLDescription" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the WSDL service.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ConversionDescription" type="NoteType">
+	<xsd:element name="ConversionDescription" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element for a description of the SpecialConversionFrom.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityReference" type="ReferenceType">
+	<xsd:element name="QuantityReference" type="unitsml:ReferenceType">
 		<xsd:annotation>
 			<xsd:documentation>Element for all quantities that can be expressed using this unit.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitDefinition" type="DefinitionType">
+	<xsd:element name="UnitDefinition" type="unitsml:DefinitionType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the definition of the unit.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitHistory" type="HistoryType">
+	<xsd:element name="UnitHistory" type="unitsml:HistoryType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the historical development of the unit.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitRemark" type="RemarkType">
+	<xsd:element name="UnitRemark" type="unitsml:RemarkType">
 		<xsd:annotation>
 			<xsd:documentation>Element as a placeholder for additional information.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!--     === Counted item elements ===-->
-	<xsd:element name="CountedItemSet" type="CountedItemSetType">
+	<xsd:element name="CountedItemSet" type="unitsml:CountedItemSetType">
 		<xsd:annotation>
 			<xsd:documentation>Container for items that are counted and are (in practice) combined with scientific units of measure.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="CountedItem" type="CountedItemType">
+	<xsd:element name="CountedItem" type="unitsml:CountedItemType">
 		<xsd:annotation>
 			<xsd:documentation>Container for a single counted item.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemName" type="NameType">
+	<xsd:element name="ItemName" type="unitsml:NameType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the item name(s).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemSymbol" type="SymbolType">
+	<xsd:element name="ItemSymbol" type="unitsml:SymbolType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing symbols for the item.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemVersionHistory" type="NoteType">
+	<xsd:element name="ItemVersionHistory" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element for descriptive information, including version changes to the item.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemDefinition" type="DefinitionType">
+	<xsd:element name="ItemDefinition" type="unitsml:DefinitionType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the definition of the item.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemHistory" type="HistoryType">
+	<xsd:element name="ItemHistory" type="unitsml:HistoryType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the historical development of the item.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ItemRemark" type="RemarkType">
+	<xsd:element name="ItemRemark" type="unitsml:RemarkType">
 		<xsd:annotation>
 			<xsd:documentation>Element as a placeholder for additional information.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!--     === Quantity elements ===-->
-	<xsd:element name="QuantitySet" type="QuantitySetType">
+	<xsd:element name="QuantitySet" type="unitsml:QuantitySetType">
 		<xsd:annotation>
 			<xsd:documentation>Container for quantities.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Quantity" type="QuantityType">
+	<xsd:element name="Quantity" type="unitsml:QuantityType">
 		<xsd:annotation>
 			<xsd:documentation>Element for describing quantities and referencing corresponding units. Use in container or directly incorporate into a host schema.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityName" type="NameType">
+	<xsd:element name="QuantityName" type="unitsml:NameType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the quantity name.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantitySymbol" type="SymbolType">
+	<xsd:element name="QuantitySymbol" type="unitsml:SymbolType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UnitReference" type="ReferenceType">
+	<xsd:element name="UnitReference" type="unitsml:ReferenceType">
 		<xsd:annotation>
 			<xsd:documentation>Element for referencing a unit of measure from within the Quantity element.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityVersionHistory" type="NoteType">
+	<xsd:element name="QuantityVersionHistory" type="unitsml:NoteType">
 		<xsd:annotation>
 			<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityDefinition" type="DefinitionType">
+	<xsd:element name="QuantityDefinition" type="unitsml:DefinitionType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the definition of the quantity.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityHistory" type="HistoryType">
+	<xsd:element name="QuantityHistory" type="unitsml:HistoryType">
 		<xsd:annotation>
 			<xsd:documentation>Element to describe the historical development of the quantity.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QuantityRemark" type="RemarkType">
+	<xsd:element name="QuantityRemark" type="unitsml:RemarkType">
 		<xsd:annotation>
 			<xsd:documentation>Element as a placeholder for additional information.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!--     === Dimension elements ===-->
-	<xsd:element name="DimensionSet" type="DimensionSetType">
+	<xsd:element name="DimensionSet" type="unitsml:DimensionSetType">
 		<xsd:annotation>
 			<xsd:documentation>Container for dimensions.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Dimension" type="DimensionType">
+	<xsd:element name="Dimension" type="unitsml:DimensionType">
 		<xsd:annotation>
 			<xsd:documentation>Element to express the dimension of a unit or quantity in terms of the SI base quantities length, mass, time, electric current, thermodynamic temperature, amount of substance, and luminous intensity.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Length" type="LengthType">
+	<xsd:element name="Length" type="unitsml:LengthType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity length.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Mass" type="MassType">
+	<xsd:element name="Mass" type="unitsml:MassType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity mass.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Time" type="TimeType">
+	<xsd:element name="Time" type="unitsml:TimeType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity time.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ElectricCurrent" type="ElectricCurrentType">
+	<xsd:element name="ElectricCurrent" type="unitsml:ElectricCurrentType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity electric current.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ThermodynamicTemperature" type="ThermodynamicTemperatureType">
+	<xsd:element name="ThermodynamicTemperature" type="unitsml:ThermodynamicTemperatureType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity thermodynamic temerature.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="AmountOfSubstance" type="AmountOfSubstanceType">
+	<xsd:element name="AmountOfSubstance" type="unitsml:AmountOfSubstanceType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity amount of substance.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="LuminousIntensity" type="LuminousIntensityType">
+	<xsd:element name="LuminousIntensity" type="unitsml:LuminousIntensityType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity luminous intensity.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PlaneAngle" type="PlaneAngleType">
+	<xsd:element name="PlaneAngle" type="unitsml:PlaneAngleType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of the quantity plane angle.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Item" type="ItemType">
+	<xsd:element name="Item" type="unitsml:ItemType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the dimension of any item. Note: this element is meant to be used to allow counted items to be included in the dimensioning of a derived quantity, e.g., electrons per time; usage of this element does not conform to the SI description of the dimension of a quantity in terms of seven base quantities.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!--     === Prefix elements ===-->
-	<xsd:element name="PrefixSet" type="PrefixSetType">
+	<xsd:element name="PrefixSet" type="unitsml:PrefixSetType">
 		<xsd:annotation>
 			<xsd:documentation>Container for prefixes.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Prefix" type="PrefixType">
+	<xsd:element name="Prefix" type="unitsml:PrefixType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing information about a prefix.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PrefixName" type="NameType">
+	<xsd:element name="PrefixName" type="unitsml:NameType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing the prefix name.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PrefixSymbol" type="SymbolType">
+	<xsd:element name="PrefixSymbol" type="unitsml:SymbolType">
 		<xsd:annotation>
 			<xsd:documentation>Element containing prefix symbols.</xsd:documentation>
 		</xsd:annotation>
@@ -405,7 +419,7 @@ PURPOSE.
 			<xsd:documentation>Type for the unit container.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="Unit" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:Unit" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for describing units. Use in containers UnitSet or directly incorporate into a host schema.</xsd:documentation>
 				</xsd:annotation>
@@ -417,29 +431,29 @@ PURPOSE.
 			<xsd:documentation>Type for the unit.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="UnitSystem" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:UnitSystem" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Container for describing the system(s) of units.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="UnitName" maxOccurs="unbounded"/>
-			<xsd:element ref="UnitSymbol" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="RootUnits" minOccurs="0">
+			<xsd:element ref="unitsml:UnitName" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:UnitSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:CodeListValue" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:RootUnits" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered root units.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="Conversions" minOccurs="0"/>
-			<xsd:element ref="QuantityReference" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="UnitVersionHistory" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:Conversions" minOccurs="0"/>
+			<xsd:element ref="unitsml:QuantityReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:UnitVersionHistory" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for descriptive information, including version changes to the unit.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="UnitDefinition" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="UnitHistory" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="UnitRemark" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:UnitDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:UnitHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:UnitRemark" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="required"/>
 		<xsd:attribute name="timeStamp" type="xsd:dateTime">
@@ -447,7 +461,7 @@ PURPOSE.
 				<xsd:documentation>Used to indicate the version of the unit output from the Units Database. Changes in the time-stamp are made if a substantive change has been made to the unit, such as a change in the unit definition or changes in conversion factors.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="dimensionURL">
+		<xsd:attributeGroup ref="unitsml:dimensionURL">
 			<xsd:annotation>
 				<xsd:documentation>Reference to a representation of the unit or quantity in terms of the 7 SI base dimensions.</xsd:documentation>
 			</xsd:annotation>
@@ -498,12 +512,12 @@ PURPOSE.
 			<xsd:documentation>Type for the container for defining derived units in terms of their root units. This allows a precise definition of a wide range of units. The goal is to improve interoperability among applications and databases which use derived units based on commonly encountered base units.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="EnumeratedRootUnit" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:EnumeratedRootUnit" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for a root unit (from an extensive enumerated list) allowing an optional prefix and power. E.g., mm^2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="ExternalRootUnit" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:ExternalRootUnit" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for those special cases where the root unit needed is not included in the enumerated list in the above element.</xsd:documentation>
 				</xsd:annotation>
@@ -524,13 +538,13 @@ PURPOSE.
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="sourceURL"/>
-		<xsd:attributeGroup ref="prefix">
+		<xsd:attributeGroup ref="unitsml:sourceURL"/>
+		<xsd:attributeGroup ref="unitsml:prefix">
 			<xsd:annotation>
 				<xsd:documentation>Prefix identifier; e.g., m, k, M, G. [Enumeration order is by prefix magnitude (Y to y) followed by binary prefixes.]</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attributeGroup>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="ExternalRootUnitType">
 		<xsd:annotation>
@@ -541,7 +555,7 @@ PURPOSE.
 				<xsd:documentation>URI to identify the unit.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="sourceURL">
+		<xsd:attributeGroup ref="unitsml:sourceURL">
 			<xsd:annotation>
 				<xsd:documentation>URI identifying the source and possibly the definition of the unit.</xsd:documentation>
 			</xsd:annotation>
@@ -552,25 +566,25 @@ PURPOSE.
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute ref="xml:lang"/>
-		<xsd:attributeGroup ref="prefix"/>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:prefix"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="ConversionsType">
 		<xsd:annotation>
 			<xsd:documentation>Type for the container for providing conversion information to other units.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="Float64ConversionFrom" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:Float64ConversionFrom" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for providing factors for a conversion equation from another unit; y = d + ((b / c) (x + a)). Note: The related "conversion to" equation is a simple inversion of the above equation; i.e., x = ((c / b) (y - d)) - a.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="SpecialConversionFrom" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:SpecialConversionFrom" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for describing a conversion that cannot be described by the linear expression in the element Float64ConversionFrom.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="WSDLConversionFrom" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:WSDLConversionFrom" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for providing conversion based on SOAP/WSDL calls to a remote server.</xsd:documentation>
 				</xsd:annotation>
@@ -582,10 +596,10 @@ PURPOSE.
 			<xsd:documentation>Type for the element for providing factors for a conversion equation from another unit; y = d + ((b / c) (x + a))</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="ConversionNote" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ConversionNote" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="required"/>
-		<xsd:attributeGroup ref="initialUnit"/>
+		<xsd:attributeGroup ref="unitsml:initialUnit"/>
 		<xsd:attribute name="initialAddend" type="xsd:double" default="0">
 			<xsd:annotation>
 				<xsd:documentation>Number to be added at the start of the conversion (prior to multiplication or division) [factor 'a' in equation].</xsd:documentation>
@@ -645,7 +659,7 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for the element for providing unit conversion information for conversions that are more complex than the Float64ConversionFrom linear equation.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="ConversionDescription" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:ConversionDescription" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Description of the conversion.</xsd:documentation>
 				</xsd:annotation>
@@ -657,21 +671,21 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>URL for external description of the conversion or for an online convertor.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="initialUnit"/>
+		<xsd:attributeGroup ref="unitsml:initialUnit"/>
 	</xsd:complexType>
 	<xsd:complexType name="WSDLConversionFromType">
 		<xsd:annotation>
 			<xsd:documentation>Type for the element for providing unit conversion information for conversions that are more complex than the Float64ConversionFrom linear equation.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="WSDLDescription" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:WSDLDescription" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Description of the service.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="required"/>
-		<xsd:attributeGroup ref="initialUnit"/>
+		<xsd:attributeGroup ref="unitsml:initialUnit"/>
 		<xsd:attribute name="wsdlURL" type="xsd:anyURI" use="required">
 			<xsd:annotation>
 				<xsd:documentation>URL for external WSDL definition file.</xsd:documentation>
@@ -684,7 +698,7 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for a set of counted items.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="CountedItem" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:CountedItem" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="CountedItemType">
@@ -692,12 +706,12 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for a single counted item.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="ItemName" maxOccurs="unbounded"/>
-			<xsd:element ref="ItemSymbol" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="ItemVersionHistory" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="ItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="ItemHistory" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="ItemRemark" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ItemName" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ItemSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ItemVersionHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ItemHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:ItemRemark" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="required"/>
 	</xsd:complexType>
@@ -707,7 +721,7 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for quantity container.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="Quantity" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:Quantity" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="QuantityType">
@@ -715,25 +729,25 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for the quantity.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="QuantityName" maxOccurs="unbounded"/>
-			<xsd:element ref="QuantitySymbol" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:QuantityName" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:QuantitySymbol" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element containing various quantity symbols.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="UnitReference" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:UnitReference" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for specifying particular units associated with the quantity.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="QuantityVersionHistory" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:QuantityVersionHistory" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element for descriptive information, including version changes to the quantity.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="QuantityDefinition" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="QuantityHistory" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element ref="QuantityRemark" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:QuantityDefinition" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:QuantityHistory" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:QuantityRemark" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="required"/>
 		<xsd:attribute name="quantityType" use="optional">
@@ -748,7 +762,7 @@ additive inverse of this number.</xsd:documentation>
 			</xsd:simpleType>
 			<!-- REVISE -->
 		</xsd:attribute>
-		<xsd:attributeGroup ref="dimensionURL"/>
+		<xsd:attributeGroup ref="unitsml:dimensionURL"/>
 	</xsd:complexType>
 	<!--     === Dimension specific Types ===-->
 	<xsd:complexType name="DimensionSetType">
@@ -756,7 +770,7 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for the dimension container.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="Dimension" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:Dimension" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element to express a unit or quantity in terms of the SI base quantities length, mass, time, electric current, thermodynamic temperature, amount of substance, and luminous intensity.</xsd:documentation>
 				</xsd:annotation>
@@ -771,15 +785,15 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:annotation>
 				<xsd:documentation>This unbounded sequence allows any order of any number of elements; e.g., L^1 Â· L^-1.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:element ref="Length" minOccurs="0"/>
-			<xsd:element ref="Mass" minOccurs="0"/>
-			<xsd:element ref="Time" minOccurs="0"/>
-			<xsd:element ref="ElectricCurrent" minOccurs="0"/>
-			<xsd:element ref="ThermodynamicTemperature" minOccurs="0"/>
-			<xsd:element ref="AmountOfSubstance" minOccurs="0"/>
-			<xsd:element ref="LuminousIntensity" minOccurs="0"/>
-			<xsd:element ref="PlaneAngle" minOccurs="0"/>
-			<xsd:element ref="Item" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="unitsml:Length" minOccurs="0"/>
+			<xsd:element ref="unitsml:Mass" minOccurs="0"/>
+			<xsd:element ref="unitsml:Time" minOccurs="0"/>
+			<xsd:element ref="unitsml:ElectricCurrent" minOccurs="0"/>
+			<xsd:element ref="unitsml:ThermodynamicTemperature" minOccurs="0"/>
+			<xsd:element ref="unitsml:AmountOfSubstance" minOccurs="0"/>
+			<xsd:element ref="unitsml:LuminousIntensity" minOccurs="0"/>
+			<xsd:element ref="unitsml:PlaneAngle" minOccurs="0"/>
+			<xsd:element ref="unitsml:Item" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Element containing the dimension of any item. Note: this element is meant to be used to allow counted items to be included in the dimensioning of a derived quantity, e.g., electrons per time; usage of this element does not conform to the SI description of the dimension of a quantity in terms of seven base quantities.</xsd:documentation>
 				</xsd:annotation>
@@ -801,7 +815,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity length.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="MassType">
 		<xsd:annotation>
@@ -812,7 +826,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity mass.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="TimeType">
 		<xsd:annotation>
@@ -823,7 +837,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity time.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+	    <xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="ElectricCurrentType">
 		<xsd:annotation>
@@ -834,7 +848,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity electric current.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="ThermodynamicTemperatureType">
 		<xsd:annotation>
@@ -845,7 +859,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity thermodynamic temperature.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="AmountOfSubstanceType">
 		<xsd:annotation>
@@ -856,7 +870,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity amount of substance.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="LuminousIntensityType">
 		<xsd:annotation>
@@ -867,7 +881,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity luminous intensity.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="PlaneAngleType">
 		<xsd:annotation>
@@ -878,7 +892,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol of the quantity plane angle.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<xsd:complexType name="ItemType">
 		<xsd:annotation>
@@ -894,7 +908,7 @@ additive inverse of this number.</xsd:documentation>
 				<xsd:documentation>Symbol for the item.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attributeGroup ref="powerRational"/>
+		<xsd:attributeGroup ref="unitsml:powerRational"/>
 	</xsd:complexType>
 	<!--     === Prefix specific Types ===-->
 	<xsd:complexType name="PrefixSetType">
@@ -902,7 +916,7 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for container for prefixes.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="Prefix" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:Prefix" maxOccurs="unbounded"/>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="PrefixType">
@@ -910,8 +924,8 @@ additive inverse of this number.</xsd:documentation>
 			<xsd:documentation>Type for element for describing prefixes. Use in container PrefixSet.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="PrefixName" maxOccurs="unbounded"/>
-			<xsd:element ref="PrefixSymbol" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:PrefixName" maxOccurs="unbounded"/>
+			<xsd:element ref="unitsml:PrefixSymbol" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute ref="xml:id" use="required"/>
 		<xsd:attribute name="prefixBase" default="10">
@@ -1002,8 +1016,8 @@ additive inverse of this number.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:extension base="xsd:string">
-				<xsd:attributeGroup ref="sourceURL"/>
-				<xsd:attributeGroup ref="sourceName"/>
+			    <xsd:attributeGroup ref="unitsml:sourceURL"/>
+			    <xsd:attributeGroup ref="unitsml:sourceName"/>
 				<xsd:attribute ref="xml:lang"/>
 			</xsd:extension>
 		</xsd:simpleContent>
@@ -1014,8 +1028,8 @@ additive inverse of this number.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:extension base="xsd:string">
-				<xsd:attributeGroup ref="sourceURL"/>
-				<xsd:attributeGroup ref="sourceName"/>
+			    <xsd:attributeGroup ref="unitsml:sourceURL"/>
+			    <xsd:attributeGroup ref="unitsml:sourceName"/>
 				<xsd:attribute ref="xml:lang"/>
 			</xsd:extension>
 		</xsd:simpleContent>
@@ -1026,8 +1040,8 @@ additive inverse of this number.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:extension base="xsd:string">
-				<xsd:attributeGroup ref="sourceURL"/>
-				<xsd:attributeGroup ref="sourceName"/>
+			    <xsd:attributeGroup ref="unitsml:sourceURL"/>
+			    <xsd:attributeGroup ref="unitsml:sourceName"/>
 				<xsd:attribute ref="xml:lang">
 					<xsd:annotation>
 						<xsd:documentation>Primary language of the element and/or its attributes. [See RFC 4646, RFC 4647 and ISO 639.]</xsd:documentation>

--- a/templates/unitsml-v2.0.template
+++ b/templates/unitsml-v2.0.template
@@ -1429,6 +1429,16 @@ additive inverse of this number.</xsd:documentation>
 			<!-- REVISE -->
 		</xsd:attribute>
 		<xsd:attributeGroup ref="unitsml:dimensionURL"/>
+		<xsd:attribute name="scale">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="ratio"/>
+					<xsd:enumeration value="interval"/>
+					<xsd:enumeration value="ordinal"/>
+					<xsd:enumeration value="cardinal"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
 		<xsd:assert test="(@xml:id or (@domain and @key and @version))">
 			<xsd:annotation>
 				<xsd:documentation>Require at least one identification type via xml:id or domain,

--- a/templates/unitsml-v2.0.template
+++ b/templates/unitsml-v2.0.template
@@ -1769,8 +1769,7 @@ additive inverse of this number.</xsd:documentation>
 						changes to the constant.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0"
-				maxOccurs="1"/>
+			<xsd:element name="PreviousVersion" type="unitsml:KeyedReferenceType" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="unitsml:ConstantDefinition" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ConstantHistory" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element ref="unitsml:ConstantRemark" minOccurs="0" maxOccurs="unbounded"/>
@@ -1778,6 +1777,7 @@ additive inverse of this number.</xsd:documentation>
 		<xsd:attribute ref="xml:id" use="optional"/>
 		<xsd:attributeGroup ref="unitsml:optionalKeyedReferenceAttributeGroup"/>
 		<xsd:attributeGroup ref="unitsml:timestamp"/>
+		<xsd:attribute name="exact" type="xsd:boolean" default="false"/>
 		<xsd:assert test="(@xml:id or (@domain and @key and @version))">
 			<xsd:annotation>
 				<xsd:documentation>Require at least one identification type via xml:id or domain,

--- a/templates/unitsml-v2.0.template
+++ b/templates/unitsml-v2.0.template
@@ -1808,7 +1808,7 @@ additive inverse of this number.</xsd:documentation>
 					DimensionReference element but not both.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:assert>
-		<xsd:assert test="exists(./unitsml:CountableItemReference) and not(exists(./unitsml:ComplexValue))">
+		<xsd:assert test="(not(exists(./unitsml:CountableItemReference) or (exists(./unitsml:CountableItemReference) and not(exists(./unitsml:ComplexValue)))))">
 			<xsd:annotation>
 				<xsd:documentation>The cannot be a complex value with a countable item reference.</xsd:documentation>
 			</xsd:annotation>

--- a/test.py
+++ b/test.py
@@ -1,0 +1,61 @@
+import unittest
+import xmlschema
+
+class Test_UnitsXML(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._schema = xmlschema.XMLSchema11('./unitsml/unitsml-v2.0.xsd')
+    def test_valid_full_instance(self):
+        try:
+            self._schema.validate('./tests/valid.xml')
+        except Exception as e:
+            self.fail("Invalid.")
+    def test_duplicate_regulatoryBody(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/regulatoryBody_duplicate.xml')
+    def test_invalid_unitset_domain(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unitset_invalid_domain.xml')
+    def test_invalid_unitset_domain_conflict(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unitset_conflicting_domain.xml')
+
+    def test_invalid_unique_unit(self): 
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unique_unit.xml')
+    def test_invalid_unit_domain(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_invalid_NMI.xml')
+    def test_unit_partial_composite_key(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_partial_composite_key.xml')
+    def test_unit_partial_composite_key_version(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_partial_composite_key_version.xml')
+    def test_unit_invalid_root_unit_prefix_reference(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_invalid_root_unit_prefix_reference.xml')
+    def test_unit_invalid_root_unit_unit_reference_in_prefix_ref(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_invalid_root_unit_unit_reference_in_prefix_ref.xml')
+    def test_unit_invalid_root_unit_unit_reference(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_invalid_root_unit_unit_reference.xml')
+    def test_unit_invalid_quantity_reference(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_invalid_quantity_reference.xml')
+    def test_invalid_unit_previousVersion(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_previousVersion.xml')
+    def test_unit_version_predates_ancestor(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_version_predates_ancestor.xml')
+    def test_unit_too_high_initial_version(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_too_high_initial_version.xml')
+    def test_invalid_unit_DSI(self):
+        with self.assertRaises(xmlschema.validators.exceptions.XMLSchemaValidationError):
+            self._schema.validate('./tests/unit_D-SI.xml')
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/regulatoryBody_duplicate.xml
+++ b/tests/regulatoryBody_duplicate.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unique_unit.xml
+++ b/tests/unique_unit.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_D-SI.xml
+++ b/tests/unit_D-SI.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metr</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_invalid_NMI.xml
+++ b/tests/unit_invalid_NMI.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI3" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_invalid_quantity_reference.xml
+++ b/tests/unit_invalid_quantity_reference.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" version="1" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="3"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_invalid_root_unit_prefix_reference.xml
+++ b/tests/unit_invalid_root_unit_prefix_reference.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" version="1" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="k" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_invalid_root_unit_unit_reference.xml
+++ b/tests/unit_invalid_root_unit_unit_reference.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" version="1" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NM"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_invalid_root_unit_unit_reference_in_prefix_ref.xml
+++ b/tests/unit_invalid_root_unit_unit_reference_in_prefix_ref.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" version="1" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="mete" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_partial_composite_key.xml
+++ b/tests/unit_partial_composite_key.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_partial_composite_key_version.xml
+++ b/tests/unit_partial_composite_key_version.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_previousVersion.xml
+++ b/tests/unit_previousVersion.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_too_high_initial_version.xml
+++ b/tests/unit_too_high_initial_version.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" version="1" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unit_version_predates_ancestor.xml
+++ b/tests/unit_version_predates_ancestor.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" domain="NMI" version="1" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2022-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unitset_conflicting_domain.xml
+++ b/tests/unitset_conflicting_domain.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/unitset_invalid_domain.xml
+++ b/tests/unitset_invalid_domain.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet domain="NMI3">
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>

--- a/tests/valid.xml
+++ b/tests/valid.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unitsml:UnitsML xmlns:unitsml="https://schema.unitsml.org/unitsml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <unitsml:RegulatoryBody domainKey="NMI">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for an NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:RegulatoryBody domainKey="NMI2">
+        <vcard xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+            <fn>
+                <text>NMI2</text>
+            </fn>
+        </vcard>
+        <unitsml:Description>An example for another NMI</unitsml:Description>
+    </unitsml:RegulatoryBody>
+    <unitsml:UnitSet>
+        <unitsml:Unit xml:id="Unit1" key="meter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML"><b>m</b></unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Length"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Distance"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit2" key="meter" version="2" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:CodeListValue IRDI="0112/2///62720#UAA726#002"/>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+            <unitsml:QuantityReference domain="NMI" key="length" version="1"/>
+            <unitsml:UnitVersionHistory>Some history</unitsml:UnitVersionHistory>
+            <unitsml:PreviousVersion domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitHistory>More history</unitsml:UnitHistory>
+            <unitsml:UnitRemark>A remark</unitsml:UnitRemark>
+        </unitsml:Unit>
+        <unitsml:Unit xml:id="Unit5" key="mixedRefmeter" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">unrealisticUnit</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\mega\metre\metre</unitsml:UnitSymbol>
+            <unitsml:RootUnits>
+                <unitsml:PrefixReference key="M" version="1" domain="NMI">
+                    <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+                </unitsml:PrefixReference>
+                <unitsml:UnitReference key="meter" version="1" domain="NMI"/>
+            </unitsml:RootUnits>
+        </unitsml:Unit>
+        <unitsml:Unit key="one" version="1" domain="NMI" timeStamp="2023-01-01T00:00:01Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">1</unitsml:UnitName>
+            <unitsml:UnitSymbol type="D-SI">\one</unitsml:UnitSymbol>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:UnitSet domain="NMI2">
+        <unitsml:Unit xml:id="Unit3" key="meter" version="1" domain="NMI2" timeStamp="2023-01-01T00:00:00Z">
+            <unitsml:UnitSystem type="SI_base" name="SI"/>
+            <unitsml:UnitName xml:lang="en-US">meter</unitsml:UnitName>
+            <unitsml:UnitSymbol type="ASCII">meter</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="HTML">m</unitsml:UnitSymbol>
+            <unitsml:UnitSymbol type="D-SI">\metre</unitsml:UnitSymbol>
+            <unitsml:QuantityReference xml:lang="en-US" name="length" url="#Quantity1"/>
+            <unitsml:QuantityReference xml:lang="en-US" name="distance" url="#Quantity2"/>
+        </unitsml:Unit>
+    </unitsml:UnitSet>
+    <unitsml:CountedItemSet>
+        <unitsml:CountedItem domain="NMI" key="particles" version="1">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+        <unitsml:CountedItem domain="NMI" key="particles" version="2">
+            <unitsml:ItemName>particles</unitsml:ItemName>
+            <unitsml:ItemSymbol type="ASCII">particles</unitsml:ItemSymbol>
+            <unitsml:CodeListValue IRDI="INVALID"/>
+            <unitsml:PreviousVersion version="1" domain="NMI" key="particles"/>
+            <unitsml:ItemDefinition>Number of particles</unitsml:ItemDefinition>
+            <unitsml:ItemHistory>The items history</unitsml:ItemHistory>
+            <unitsml:ItemRemark>A remark</unitsml:ItemRemark>
+        </unitsml:CountedItem>
+    </unitsml:CountedItemSet>
+    <unitsml:QuantitySet>
+        <unitsml:Quantity domain="NMI" key="length" version="1" quantityType="base">
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="1" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference domain="NMI" key="meter" version="2"/>
+            <unitsml:UnitReference url="None"/>
+        </unitsml:Quantity>
+        <unitsml:Quantity domain="NMI" key="roughness" version="2" quantityType="base">
+            <unitsml:DimensionReference domain="NMI" key="length" version="1"/>
+            <unitsml:QuantityName>Length</unitsml:QuantityName>
+            <unitsml:UnitReference domain="NMI" key="meter" version="1"/>
+            <unitsml:UnitReference url="None"/>
+            <unitsml:PreviousVersion domain="NMI" key="roughness" version="1"/>
+        </unitsml:Quantity>
+    </unitsml:QuantitySet>
+    <unitsml:DimensionSet>
+        <unitsml:Dimension domain="NMI" key="length" version="1">
+            <unitsml:Length/>
+        </unitsml:Dimension>
+        <unitsml:Dimension domain="NMI" key="one" version="1" dimensionless="true"/>
+    </unitsml:DimensionSet>
+    <unitsml:PrefixSet>
+        <unitsml:Prefix key="M" prefixPower="6" domain="NMI">
+            <unitsml:PrefixName>Mega</unitsml:PrefixName>
+            <unitsml:PrefixSymbol type="ASCII">M</unitsml:PrefixSymbol>
+        </unitsml:Prefix>
+    </unitsml:PrefixSet>
+    <unitsml:ConstantSet>
+        <unitsml:Constant domain="NMI" key="pi" version="1">
+            <unitsml:RealValue>3.14159265359</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+        </unitsml:Constant>
+        <unitsml:Constant domain="NMI" key="pi" version="2">
+            <unitsml:RealValue>3.1415926536</unitsml:RealValue>
+            <unitsml:UnitReference domain="NMI" key="one" version="1"/>
+            <unitsml:ConstantName>PI</unitsml:ConstantName>
+            <unitsml:PreviousVersion domain="NMI" key="pi" version="1"/>
+        </unitsml:Constant>
+    </unitsml:ConstantSet>
+</unitsml:UnitsML>


### PR DESCRIPTION
**Preface:**
This is only a preliminary proposition for further discussion and all constructive criticism and comments are welcome. Since I have not been part of any of the previous technical committees or taken part in the discussions, I am unfamiliar with the reasons for certain design decisions. Therefore, some of my suggested changes may conflict with previous design decisions.

To avoid confusion with a published standard a temporary header was added stating that this is not a standard nor does it conform to one.

The new major version 2.0 was chosen since it introduces breaking changes. To leverage the new `assert`, `alternative` and XPath 2.0 capabilities the XML schema version was update to 1.1.

New features (short summary TODO: write documentation @y4r9):
1. A `RegulatoryBody` element was added which provides the basis for `domain` attributes in all set types and `Unit`, `CountedItem`, `Quantity`, `Dimension`, `Prefix` and the new `Constant` elements. **Reasoning:** By using the `domain` attribute an element can be referenced to a regulatory body like an NMI. The use of a uniqueness constraint and the keyref functionality permits a validation of the association.
2. In contrast to the previous version, the set elements can now occur unbounded times. **Reasoning:** This should enable grouping of the contained elements in logical sets such as by domain, by version, by type of unit etc. Additionally, the contents of a set can be constrained to only allow elements with the `domain` of the set element. TODO: the inheritance of the set `domain` attribute does not seem to be available to the assert statements.
3. Added an additional mechanism by which `RegulatoryBody`, `Unit`, `CountedItem`, `Quantity`, `Dimension`, `Prefix` and `Constant` can be referenced within an instance document using composite keys. This is further restricted by applying uniqueness constraints and requiring the histories of these elements to be strictly linear with each element being derived from an explicit ancestor or constituting the initial version of the element. Timestamps were added to supplement the versioning of elements. References using a URL are still permitted to allow for some backward compatibility requiring only minor changes.
4. Because the `RootUnits`, as defined by the enums, neither have a version history nor an explicit definition (same goes for the prefix enum), the derivation of units was extended beyond the concept of root units by allowing references to normal `Unit` elements. A `Unit` element without specified root units or references can implicitly be regarded as a base or root unit.
5. To enable validation of the symbol elements a sub type for each content type was added. TODO: Most types are not yet validated except, ASCII, MathML and D-SI. Added symbol types for the proposed D-SI standard (doi: [10.5281/zenodo.3522631](https://dx.doi.org/10.5281/zenodo.3522631)) and UCUM (see: [https://ucum.org/](https://ucum.org/)). TODO: must test for uniqueness with respect to the language or remove xml:lang from D-SI and UCUM since these are language independent.
6. Added specialized code list elements for IEC CDD (see: [https://cdd.iec.ch/](https://cdd.iec.ch/)). TODO: add more specialized code list elements for other common standards.
7. Added `ConstantSet` and `Constant` elements to allow for the definition of real and imaginary scalar constants (with an unlimited number of elements to accommodate quaternions etc.) which may reference `Unit` or `CountedItem` but not `Quantity`, because constants may be used for multiple quantities such as pi, e, electron charge and others. Furthermore, an exact attribute was added to the Constant element to allow for constants without error and uncertainty. Many constants, however, are irrational and thus cannot be presented exact in a decimal notation. Numeric precision was not taken into account, because an arbitrary math library is expected to be used. **TODO:** In this first step uncertainties cannot yet be associated with the `Constant`. One would need to add elements for symmetric, asymmetric and empirical (percentile) uncertainties and their respective distributions. Possibly add constant vectors, tensors etc. The simplistic implementation presented here should be discussed to further improve the applicability. **Reasoning:** Constants and their associated uncertainties need to versioned since they may change over time. This affects the reproducibility of calculations as well as the uncertainty of the derived results.
8. Digital signatures can now be added to the `UnitsML` element, in order to provide trustworthy lists/databases of the contents. **Reasoning:** In case an NMI or another standardization organization publishes reference lists/database for use in digital calibration certificates etc. a digital signature may be required by statutory or regulatory requirements.
9. Added a `scale` attribute enum to `Quantity` with choices of `ratio`, `interval`, `ordinal` and `cardinal`. TODO: Asserts still have to be written to enforce the restrictions.
10. Added some basic test cases for `UnitSet` and `Unit` only. TODO: expand test set.